### PR TITLE
feat(infra): add protocol services and authentik sso

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,12 @@
 .decrypted/
 notes/plans
 
+# Terraform local state and input secrets
+terraform/.terraform/
+terraform/terraform.tfstate
+terraform/terraform.tfstate.*
+terraform/*.tfvars
+
 # Python bytecode and caches
 __pycache__/
 *.py[cod]

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ up:
 	@sudo -v
 	@./scripts/run-step.sh "Running DNS bootstrap" -- bash ./scripts/setup-local-pihole-dns.sh disable
 	@./scripts/run-step.sh "Configuring registry access" -- bash ./scripts/setup-registry-home.sh
-	@./scripts/run-step.sh "Configuring ingress access" -- bash ./scripts/setup-ingress-home.sh
+	@./scripts/run-step.sh "Configuring ingress access" -- bash -c 'INGRESS_HOSTS="apps.home authentik.home" bash ./scripts/setup-ingress-home.sh'
 	@./scripts/run-step.sh "Writing K3s config" -- bash -c 'sudo mkdir -p /etc/rancher/k3s && printf "%s\n" "disable:" "  - traefik" "  - servicelb" | sudo tee /etc/rancher/k3s/config.yaml >/dev/null'
 	@./scripts/run-step.sh "Installing K3s" -- bash -c 'curl -sfL https://get.k3s.io | sh -'
 	@./scripts/run-step.sh "Waiting for K3s startup" -- sleep 10
@@ -29,6 +29,10 @@ sync:
 	@echo "Syncing Helmfile..."
 	@helmfile sync
 
+.PHONY: authentik-apply
+authentik-apply:
+	@./scripts/apply-authentik-terraform.sh
+
 # Django manage.py via kubectl. Escape hatch: make django-manage ARGS="shell"
 
 _FIRST_GOAL := $(firstword $(MAKECMDGOALS))
@@ -39,7 +43,7 @@ SHOWMIGRATIONS_EXTRAS := $(if $(filter showmigrations,$(_FIRST_GOAL)),$(wordlist
 
 STUBS_RAW := $(strip $(MIGRATE_EXTRAS) $(MIGRATIONS_EXTRAS) $(SHOWMIGRATIONS_EXTRAS))
 # Trailing words must be stub targets; exclude real Makefile goals so we never override them.
-_RESERVED_FOR_STUB := up sync down validate validate-fast update-charts django-manage image-build image-push image-build-push image-ref pihole-dns-enable pihole-dns-disable pihole-dns-status sops-age-generate migrate migrations showmigrations
+_RESERVED_FOR_STUB := up sync authentik-apply down validate validate-fast update-charts django-manage image-build image-push image-build-push image-ref pihole-dns-enable pihole-dns-disable pihole-dns-status sops-age-generate migrate migrations showmigrations
 STUBS := $(filter-out $(_RESERVED_FOR_STUB),$(STUBS_RAW))
 
 ifneq ($(STUBS),)
@@ -116,6 +120,7 @@ down:
 	@echo "Restoring default workstation DNS before cluster teardown..."
 	@bash ./scripts/setup-local-pihole-dns.sh disable
 	@sudo /usr/local/bin/k3s-uninstall.sh
+	@rm -rf terraform/.terraform terraform/terraform.tfstate terraform/terraform.tfstate.*
 
 # check for helm chart updates; prompts y/n before writing helmfile.yaml
 .PHONY: update-charts

--- a/README.md
+++ b/README.md
@@ -9,40 +9,29 @@ Personal Kubernetes homelab running on [K3s](https://k3s.io/), fully declared in
 **Prerequisites:** Linux system with `kubectl`, `helm`, and `helmfile` installed.
 
 ```bash
-# Bring up the cluster (installs K3s, deploys infra, builds local app images, deploys local apps)
+# Bring up the cluster
 make up
 
 # Re-sync after config changes
 make sync
 
-# Run the fast local checks used by the pre-commit hook
+# Run local validation
 make validate-fast
-
-# Run the full local validation pass that mirrors CI
 make validate
 
-# Tear down everything (services, PVs, and K3s)
+# Tear down the cluster
 make down
 ```
 
-`make up` bootstraps persistent local host mappings for the pinned homelab endpoints:
+`make up` installs K3s, deploys the Helmfile releases, builds local app images, and points this workstation at the in-cluster Pi-hole DNS once it is ready. Browser-facing services use `.home` hostnames, which Pi-hole resolves to Traefik so requests can be routed to the right in-cluster service.
 
-- `registry.home` -> `192.168.76.250`
-- `apps.home` -> `192.168.76.245`
-
-Those `/etc/hosts` entries stay in place across repeated `make down` / `make up` cycles. The IPs stay stable because both the registry and Traefik are pinned inside the MetalLB pool.
-
-`make up` also flips this workstation to the in-cluster Pi-hole automatically after Pi-hole is healthy, and `make down` flips it back to normal DHCP-provided DNS before teardown.
-
-If you need to toggle that behavior manually on this machine, use:
+To toggle homelab DNS manually on this machine:
 
 ```bash
 make pihole-dns-enable
 make pihole-dns-disable
 make pihole-dns-status
 ```
-
-That points this machine's active NetworkManager connection at the cluster Pi-hole DNS service without changing the rest of the LAN. This enables all services to be accessible by their `.home` hostnames without additional configuration on this machine.
 
 ### Default Access
 
@@ -52,6 +41,7 @@ That points this machine's active NetworkManager connection at the cluster Pi-ho
 | Prometheus     | [prometheus.home](http://prometheus.home)       | —                                                               |
 | Home Assistant | [homeassistant.home](http://homeassistant.home) | Setup on first visit                                            |
 | Headlamp       | [headlamp.home](http://headlamp.home)           | `kubectl create token headlamp -n kube-system --duration=8760h` |
+| Authentik      | [authentik.home](http://authentik.home)         | Setup on first visit                                            |
 | Longhorn UI    | [longhorn.home](http://longhorn.home)           | —                                                               |
 | Pi-hole        | [pihole.home/admin/](http://pihole.home/admin/) | admin / `pihole`                                                |
 | Apps           | [apps.home](http://apps.home)                   | —                                                               |
@@ -73,6 +63,7 @@ That points this machine's active NetworkManager connection at the cluster Pi-ho
 | [PostgreSQL](services/postgres/)                       | Shared database for homelab-owned applications                 |
 | [Registry](services/registry/)                         | Local registry for Docker images built from `apps/`            |
 | [Home Assistant](services/home-assistant/)             | Home automation platform                                       |
+| [Mosquitto](services/mosquitto/)                       | MQTT broker for smart-home integrations                        |
 | [Pi-hole](services/pihole/)                            | DNS and `.home` records                                        |
 | [Headlamp](services/headlamp/)                         | Kubernetes dashboard; optional if `kubectl` is enough          |
 | [Authentik](services/authentik/)                       | SSO / OIDC identity provider (WIP)                             |
@@ -80,6 +71,13 @@ That points this machine's active NetworkManager connection at the cluster Pi-ho
 | [Django](apps/django/)                                 | Database migration tool and admin interface                    |
 | [Runner](apps/runner/)                                 | Internal UI for running approved app-owned jobs                |
 | [Workload Chart Example](apps/workload-chart-example/) | Deployed reference app using the workload chart                |
+
+### Prepared but Disabled
+
+| Service                                                        | Description                                                           |
+| -------------------------------------------------------------- | --------------------------------------------------------------------- |
+| [Zigbee2MQTT](services/zigbee2mqtt/)                           | Zigbee coordinator bridge; enable after a Zigbee USB stick is present |
+| [OpenThread Border Router](services/openthread-border-router/) | Thread border router; enable after a Thread RCP stick is present      |
 
 ## Network Flow
 
@@ -139,6 +137,19 @@ sops -d services/<service>/secrets.sops.yaml
 
 Add new secret files to the release's `secrets:` list in `helmfile.yaml` so Helmfile decrypts and merges them during `helmfile sync`.
 
+## Authentik SSO
+
+Authentik is exposed at [authentik.home](http://authentik.home) and uses the shared Postgres release for durable state. On first boot, finish the Authentik initial setup in the UI and create an API token.
+
+If `TF_VAR_authentik_token` is set, `make up` applies the Terraform configuration after the infra Helmfile sync. That creates the Grafana OAuth client in Authentik, stores the generated client credentials in the `grafana-oauth-secret` Kubernetes Secret, and restarts Grafana so it can offer Authentik login.
+
+For an existing cluster, run:
+
+```bash
+export TF_VAR_authentik_token='<token>'
+make authentik-apply
+```
+
 ## Project Layout
 
 ```
@@ -160,20 +171,3 @@ homelab/
 │   └── ...
 └── notes/                        # Reference notes
 ```
-
-## App workloads
-
-Homelab-owned apps deploy through the shared [`charts/workload`](charts/workload/) chart. Each app keeps a small `apps/<app>/values.yaml` with only what differs per service (env, probes, ingress paths, jobs).
-
-The chart assumes a **single personal cluster**—no staging/prod split—so several values are defaulted and omitted from app files:
-
-| Default                                       | Why                                                                                                                               |
-| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| Image `registry.home:5000/homelab/<app>:dev`  | Release name matches `apps/<app>/` and `make image-build-push SERVICE=<app>`; tag stays `dev` unless you override it in the chart |
-| `image.pullPolicy: Always`                    | Local registry + frequent `dev` rebuilds; pods should pick up new images after push                                               |
-| `scale.replicas: 1`                           | Most apps are single-replica unless HPA is enabled                                                                                |
-| `service.port` → container port               | One port knob instead of duplicating `containerPort` and Service port                                                             |
-| `app.kubernetes.io/component: <app>`          | Consistent labeling without repeating `podLabels`                                                                                 |
-| ServiceMonitor path/interval/Prometheus label | Same scrape shape for every metrics-enabled app                                                                                   |
-
-See [`charts/workload/README.md`](charts/workload/README.md) for the full values API and examples.

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -19,6 +19,8 @@ repositories:
     url: https://charts.goauthentik.io
   - name: twuni
     url: https://twuni.github.io/docker-registry.helm
+  - name: bjw-s
+    url: https://bjw-s-labs.github.io/helm-charts
 releases:
   - name: prometheus-operator
     namespace: monitoring
@@ -40,6 +42,7 @@ releases:
           - apply
           - -f
           - services/grafana/dashboards/
+
   - name: loki
     namespace: monitoring
     labels:
@@ -48,6 +51,7 @@ releases:
     version: 6.53.0
     values:
       - services/loki/values.yaml
+
   - name: promtail
     namespace: monitoring
     labels:
@@ -56,6 +60,7 @@ releases:
     version: 6.17.1
     values:
       - services/promtail/values.yaml
+
   - name: postgres
     namespace: postgres
     createNamespace: true
@@ -67,6 +72,7 @@ releases:
     needs:
       - longhorn-system/longhorn
     wait: true
+
   - name: home-assistant
     namespace: home-automation
     createNamespace: true
@@ -77,7 +83,51 @@ releases:
     values:
       - services/home-assistant/values.yaml
     needs:
+      - home-automation/mosquitto
       - monitoring/prometheus-operator
+
+  - name: mosquitto
+    namespace: home-automation
+    createNamespace: true
+    labels:
+      bootstrap: infra
+    chart: bjw-s/app-template
+    version: 4.6.2
+    values:
+      - services/mosquitto/values.yaml
+    needs:
+      - longhorn-system/longhorn
+    wait: true
+
+  - name: zigbee2mqtt
+    installed: false
+    namespace: home-automation
+    createNamespace: true
+    labels:
+      bootstrap: infra
+    chart: bjw-s/app-template
+    version: 4.6.2
+    values:
+      - services/zigbee2mqtt/values.yaml
+    needs:
+      - home-automation/mosquitto
+      - kube-system/traefik
+      - longhorn-system/longhorn
+    wait: true
+
+  - name: openthread-border-router
+    installed: false
+    namespace: home-automation
+    createNamespace: true
+    labels:
+      bootstrap: infra
+    chart: bjw-s/app-template
+    version: 4.6.2
+    values:
+      - services/openthread-border-router/values.yaml
+    needs:
+      - kube-system/traefik
+
   - name: longhorn
     namespace: longhorn-system
     createNamespace: true
@@ -87,6 +137,7 @@ releases:
     version: 1.11.0
     values:
       - services/longhorn/values.yaml
+
   - name: registry
     namespace: registry
     createNamespace: true
@@ -101,6 +152,7 @@ releases:
       - metallb-system/metallb
       - monitoring/prometheus-operator
     wait: true
+
   - name: pihole
     namespace: pihole
     createNamespace: true
@@ -117,6 +169,7 @@ releases:
       - metallb-system/metallb
       - kube-system/traefik
     wait: true
+
   - name: workload-chart-example
     namespace: apps
     createNamespace: true
@@ -128,6 +181,7 @@ releases:
     needs:
       - monitoring/prometheus-operator
       - registry/registry
+
   - name: api
     namespace: apps
     labels:
@@ -141,6 +195,7 @@ releases:
       - monitoring/prometheus-operator
       - postgres/postgres
       - registry/registry
+
   - name: runner
     namespace: apps
     createNamespace: true
@@ -160,6 +215,7 @@ releases:
             kubectl apply -f apps/runner/rbac.yaml
     needs:
       - registry/registry
+
   - name: django
     namespace: apps
     labels:
@@ -173,6 +229,7 @@ releases:
     needs:
       - postgres/postgres
       - registry/registry
+
   - name: traefik
     namespace: kube-system
     labels:
@@ -181,6 +238,7 @@ releases:
     version: 39.0.5
     values:
       - services/traefik/values.yaml
+
   - name: metallb
     namespace: metallb-system
     createNamespace: true
@@ -200,6 +258,7 @@ releases:
             echo "Waiting for MetalLB webhook to be ready..."
             kubectl wait --for=condition=ready pod -l app.kubernetes.io/component=controller -n metallb-system --timeout=60s
             kubectl apply -f services/metallb/ip-pool.yaml
+
   - name: headlamp
     namespace: kube-system
     labels:
@@ -208,6 +267,21 @@ releases:
     version: 0.40.0
     values:
       - services/headlamp/values.yaml
+    hooks:
+      - events:
+          - postsync
+        showlogs: true
+        command: kubectl
+        args:
+          - -n
+          - kube-system
+          - patch
+          - deployment
+          - headlamp
+          - --type=strategic
+          - -p
+          - '{"spec":{"template":{"spec":{"hostAliases":[{"ip":"192.168.76.245","hostnames":["authentik.home"]}]}}}}'
+
   - name: authentik
     namespace: authentik
     createNamespace: true

--- a/notes/hardware/device_management.md
+++ b/notes/hardware/device_management.md
@@ -1,0 +1,115 @@
+# Smart Home Management
+
+## Power categories
+
+Smart home devices split into two main groups based on how they're powered, and the design tradeoffs are very different.
+
+### Mains-powered
+
+Tap directly into household wiring with effectively unlimited power budget. Supports always-on radios, more powerful processors, richer features.
+
+Examples: smart bulbs, hardwired thermostats (using HVAC C-wire), PoE cameras, plug-in hubs.
+
+Smart bulbs include a small AC-to-DC switching regulator to step 120V/240V down to the 3.3V or 5V the LED driver and radio need. This is why they have a persistent standby draw (typically 0.3-0.5W) even when "off" - the radio stays alive to receive commands.
+
+### Battery-powered
+
+Devices where running a wire is impractical: door/window sensors, motion sensors, temperature/humidity sensors, leak detectors, smart locks, motorized blinds, remote buttons.
+
+The engineering challenge is brutal: years of battery life from a coin cell or a couple of AAs. This forces several design constraints.
+
+## How battery devices stretch power
+
+### Low-power radios
+
+Wi-Fi is a nonstarter for battery devices. The radio is hungry and the association/handshake process burns energy. Battery sensors use Zigbee, Z-Wave, Thread, or Bluetooth LE. These protocols are designed around short bursts of transmission with the radio sleeping over 99% of the time.
+
+A Zigbee temperature sensor might wake every few minutes, take a reading, transmit ~50 bytes, and go back to deep sleep. Average current draw in the microamps.
+
+### Sleep-by-default MCUs
+
+The microcontroller spends almost all its time in deep sleep (1-10 µA) and wakes on either a timer interrupt or an external event (reed switch closing on a door sensor, PIR motion detector triggering). Active time is measured in milliseconds.
+
+### Event-driven vs polled
+
+A door sensor only transmits when the door state changes, plus an occasional heartbeat. A temperature sensor might report on a fixed interval or only when the reading changes by a threshold. Less radio time means more battery life.
+
+With this design, a CR2032 coin cell (~220 mAh) can last 2-5 years in a door sensor, and AA batteries can last 5-10 years in some Z-Wave sensors.
+
+## Naming devices
+
+When devices join via Zigbee/Thread coordinator stick, they show up with cryptic identifiers (IEEE addresses, manufacturer-assigned names). Rename them once during onboarding and the friendly name propagates everywhere.
+
+In Home Assistant the hierarchy is:
+
+- Device name: `living_room_temperature_sensor` (the physical thing)
+- Entity IDs: auto-generated, like `sensor.living_room_temperature_sensor_battery`
+- Area: `living_room` (grouping concept for automations)
+
+Naming convention: pick `{area}_{type}_{instance}` and stick to it - `family_room_blind_1`, `office_motion_sensor`, `garage_door_sensor`. Future automations will benefit from consistency.
+
+## Tracking battery levels programmatically
+
+Battery-powered devices report level as a standard attribute on whatever cadence the firmware decides.
+
+Protocol specifics:
+
+- Zigbee: `genPowerCfg` cluster (0x0001) with `batteryPercentageRemaining` and `batteryVoltage` attributes
+- Z-Wave: Battery Command Class (0x80) with `BATTERY_GET` / `BATTERY_REPORT`
+- Matter/Thread: Power Source cluster (0x002F) with `BatPercentRemaining` and `BatChargeLevel`
+- BLE: Battery Service (0x180F) with Battery Level characteristic (0x2A19)
+
+Typical reporting cadence:
+
+- Aqara/Xiaomi sensors: every 50-60 minutes
+- Sonoff sensors: every hour or two
+- Z-Wave locks: once per day or on wake-up
+- Most Thread/Matter devices: configurable, often hourly
+
+In Home Assistant these become sensor entities automatically. With Zigbee2MQTT they also publish to predictable MQTT topics like `zigbee2mqtt/front_door/battery`, which makes piping data into Prometheus, Postgres, or Lightdash straightforward.
+
+### Retention strategy
+
+Keep 30-90 days of battery telemetry. Enough to spot trend changes (sudden faster discharge often signals a firmware bug or radio interference forcing retries) without bloating the database. Set HA recorder retention accordingly or ship to longer-term storage.
+
+## Low battery automations
+
+Standard pattern - takes 30 seconds to set up.
+
+```yaml
+automation:
+  - alias: "Low battery notification"
+    trigger:
+      - platform: time
+        at: "09:00:00"
+    action:
+      - variables:
+          low_battery_devices: >
+            {{ states.sensor
+               | selectattr('attributes.device_class', 'eq', 'battery')
+               | selectattr('state', 'is_number')
+               | selectattr('state', 'lt', '30')
+               | map(attribute='name')
+               | list }}
+      - condition: template
+        value_template: "{{ low_battery_devices | length > 0 }}"
+      - service: notify.mobile_app_your_phone
+        data:
+          title: "Low batteries"
+          message: "{{ low_battery_devices | join(', ') }}"
+```
+
+### Variations worth considering
+
+- Per-device thresholds: locks at 30% (motor brownouts when low), sensors at 15% (more headroom)
+- Escalating alerts: daily reminder at 30%, hourly at 10%
+- Grafana alerting if data is already piped there - richer routing than HA's built-in
+- Slack or ntfy notifications instead of mobile push
+
+## Gotchas
+
+The reported percentage is often a lie. Many devices report based on voltage thresholds rather than coulomb counting, and discharge curves are nonlinear. Devices commonly sit at 100% for months, drop to 50%, then to 10% within a week or two. Battery voltage (when exposed separately) is sometimes more informative than the percentage.
+
+Dead-battery devices go "unavailable" in HA, not "0%". Automations should also alert on devices that haven't reported in N hours - a dead sensor stops reporting battery before it ever reports 0%.
+
+Track battery type per device (CR2032, AA, USB-C rechargeable) as a device attribute or in a separate reference table. When an alert fires, knowing what battery to grab (or whether to pull down a blind for charging) saves a trip.

--- a/notes/hardware/device_protocols.md
+++ b/notes/hardware/device_protocols.md
@@ -1,0 +1,179 @@
+# Smart Home Setup on K3s Homelab
+
+## Smart Home Device Protocols
+
+Smart home devices need a shared communication protocol to be controllable by a hub like Home Assistant. The main options:
+
+- Zigbee: mature, broad device support, mesh-based, local-only
+- Z-Wave: similar to Zigbee but proprietary, smaller ecosystem, longer range
+- Matter: newer standard backed by Apple/Google/Amazon, runs over Thread, WiFi, or Ethernet
+- Thread: network-layer mesh protocol (not a smart home standard itself, but Matter runs on it)
+- WiFi: high overhead, often cloud-dependent, avoid when possible
+
+Devices need a protocol because they speak over radio, not IP. Something has to translate radio messages into something HA can understand. The protocol defines pairing, messaging, security, and how devices form a network.
+
+## The Two Chosen: Zigbee + Matter-over-Thread
+
+For a GitOps K3s homelab:
+
+- Zigbee via Zigbee2MQTT (Z2M): workhorse protocol, broadest device support, best diagnostics, most homelab-friendly
+- Matter-over-Thread via OpenThread Border Router (OTBR): forward-looking, growing device ecosystem, multi-admin support
+
+Both protocols use the same 802.15.4 physical radio layer, but with completely different stacks on top. They can't share a single radio reliably, so two separate USB sticks are required.
+
+## The Mesh Concept
+
+Both Zigbee and Thread form self-organizing mesh networks. Devices on the same frequency with the same network credentials discover each other and route packets cooperatively.
+
+Not every device routes:
+
+- Mains-powered devices (smart plugs, bulbs, switches) act as routers, always on, forwarding traffic for others
+- Battery-powered devices (sensors, buttons) are end devices, sleep most of the time, attach to one parent router, don't extend the mesh
+
+This means the mesh gets stronger with more mains-powered devices. A good rule: at least one router per room. The coordinator/border router sits at the root, routers form the backbone, end devices hang off as leaves.
+
+Mesh formation is gradual. Devices initially connect directly to the coordinator, then discover better routes through nearby routers over hours/days. Don't relocate routers frequently after the mesh stabilizes.
+
+Common anti-pattern: smart bulbs behind dumb wall switches. Flipping the switch off kills a router and orphans its end-device children.
+
+## Coordinators and Border Routers
+
+Every protocol needs a root node that bridges the mesh to your IP network.
+
+### Zigbee Coordinator
+
+Always a dedicated USB stick. Examples:
+
+- Sonoff ZBDongle-E (~$20)
+- Home Assistant SkyConnect / Connect ZBT-1 (~$40)
+
+No consumer device gives HA a usable Zigbee coordinator. Hue Bridges, Echos, and SmartThings hubs have Zigbee radios but are locked to their own ecosystems.
+
+### Thread Border Router
+
+Built into many consumer devices because Matter requires Thread border routers to be multi-admin and interoperable:
+
+- Apple TV 4K (2nd gen+), HomePod mini
+- Google Nest Hub (2nd gen), Nest Hub Max
+- Amazon Echo (4th gen+)
+
+Or a dedicated USB stick:
+
+- HA SkyConnect (Thread mode)
+- Dedicated OTBR-compatible sticks
+
+For a homelab prioritizing GitOps and standardization, a USB stick + OTBR is the better fit. Config in code, full diagnostic visibility, no Apple/Google account dependencies.
+
+## What the Devices Actually Connect To
+
+Devices have no concept of nodes, containers, or clusters. They see only:
+
+- A radio mesh on a specific frequency
+- A network key
+- Other devices in the mesh
+
+The connection terminates at the radio. The radio lives in the USB stick. The USB stick is owned by a container running the protocol stack.
+[Device] -> [Radio in USB stick] -> [Container running protocol software] -> [HA via IP]
+
+## The Containers
+
+Sticks do nothing without software actively driving them. The radio is just hardware; the protocol intelligence lives in the container.
+
+### Zigbee2MQTT
+
+- Reads/writes the Zigbee stick over its serial interface
+- Translates Zigbee messages to MQTT topics
+- Publishes device state to a Mosquitto broker
+- HA subscribes via its MQTT integration, auto-discovers entities
+- Memory: ~80-150 MB
+
+### OpenThread Border Router
+
+- Reads/writes the Thread stick
+- Exposes the Thread network as a routable IPv6 subnet
+- HA's Matter integration talks Matter over IPv6 through the border router
+- Memory: ~30-80 MB
+
+### Mosquitto (MQTT broker)
+
+- Required by Z2M as the transport to HA
+- Can run anywhere in the cluster, but reasonable to colocate with Z2M
+- Memory: ~10-30 MB
+
+### Home Assistant
+
+- Runs anywhere in the cluster
+- Talks to Mosquitto over the cluster network (for Zigbee devices)
+- Talks to OTBR over IPv6 (for Thread/Matter devices)
+- Memory: 500 MB - 2 GB
+
+## Node Affinity: Why Containers Must Run on the Stick's Node
+
+The USB stick is a physical device on one specific machine. The host OS exposes it as `/dev/serial/by-id/...`. Containers mount that path via `hostPath`.
+
+If the container schedules onto a different node, the path either doesn't exist or points to different hardware. The container fails or talks to the wrong device.
+
+Fix: label one node and pin the protocol containers to it.
+
+```bash
+kubectl label node node-a smart-home=true
+```
+
+```yaml
+spec:
+  nodeSelector:
+    smart-home: "true"
+```
+
+Use `/dev/serial/by-id/...` paths, not `/dev/ttyUSB0`. The latter changes after reboots.
+
+## Single Pod, Not Multiple
+
+Z2M and OTBR are exclusive consumers of their hardware device. Only one process at a time can hold the serial port open. Implications:
+
+- `replicas: 1`, always
+- `strategy: Recreate`, not RollingUpdate (default would deadlock on the device)
+- No HA in the high-availability sense for the smart-home stack
+- Resilience comes from PVC backups, not multiple replicas
+
+```yaml
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+```
+
+## Deployment Layout
+
+On the smart-home node (pinned):
+
+1. Z2M, 1 replica, hostPath mount of Zigbee stick, PVC for data
+2. OTBR, 1 replica, hostPath mount of Thread stick, PVC for data
+3. Mosquitto, 1 replica, can be colocated for simplicity
+
+Elsewhere in the cluster:
+
+4. Home Assistant, runs anywhere, PVC for config and database
+
+Total smart-home-node footprint: ~200-300 MB. Plenty of headroom for other workloads on that node.
+
+## Resilience
+
+Single point of failure at the node level is unavoidable for mesh coordinators. Mitigations:
+
+- Back up Z2M's data dir (Zigbee network key, device database)
+- Back up OTBR's data (Thread credentials)
+- Document recovery: new node, label `smart-home: true`, plug in sticks, restore PVCs, pods reschedule
+- Thread supports multiple border routers on the same network for redundancy if needed; Zigbee does not
+
+## Debugging by Layer
+
+The clean layering makes failure isolation easy:
+
+- Device won't pair -> radio/stick/container issue (check Z2M or OTBR logs)
+- Paired but not in HA -> MQTT broker or HA integration issue
+- In HA but commands fail -> command path issue (HA -> broker -> container -> device)
+- Smart-home node down -> all Zigbee/Thread dead, rest of cluster fine
+- HA pod down -> mesh keeps working, just no consumer until HA returns
+
+Use the Z2M map view and OTBR topology view for mesh diagnostics. First place to look when a device gets flaky.

--- a/notes/services/authentik.md
+++ b/notes/services/authentik.md
@@ -38,7 +38,7 @@ Authentik helps with:
 - avoiding long-lived dashboard tokens where possible
 - putting SSO in front of tools that do not have great built-in auth
 - centralizing access when the lab grows beyond one person or one workstation
-- making Grafana, Headlamp, and other admin UIs feel like one secured environment
+- making admin UIs feel like one secured environment
 
 It does not solve everything by itself. You still need stable DNS, ingress, secrets, and persistence. It also adds another moving part, so it should not become a hard dependency before the cluster is stable enough to justify it.
 
@@ -55,14 +55,52 @@ The current setup uses:
 
 - external Postgres at `postgres.postgres.svc.cluster.local`
 - bundled Redis
-- a NodePort server on `30080`
-- no ingress yet
+- Traefik ingress at `authentik.home`
 
-This is good enough for an experiment, but it is not yet the desired final shape.
+This is enough for a first real integration while still keeping Authentik optional during first boot.
+
+## First Setup
+
+Authentik cannot fully bootstrap itself from Terraform on a brand-new cluster because Terraform needs an Authentik API token first. The first run is intentionally a two-step process.
+
+1. Start the cluster:
+
+   ```bash
+   make up
+   ```
+
+   If `TF_VAR_authentik_token` is not set, `make up` deploys Authentik and skips Terraform with a message explaining the next step.
+
+2. Open Authentik:
+
+   ```text
+   http://authentik.home/if/flow/initial-setup/
+   ```
+
+3. Create the initial admin user and log in.
+
+4. Create an API token in Authentik.
+
+   The token is used by Terraform to create Authentik providers, applications, and Kubernetes Secrets. If the copy button does not work over `http://authentik.home`, use a local port-forward because browser clipboard APIs are restricted on plain HTTP hostnames:
+
+   ```bash
+   kubectl -n authentik port-forward svc/authentik-server 9000:80
+   ```
+
+   Then open `http://localhost:9000` and create/copy the token there.
+
+5. Export the token and apply the Terraform-managed Authentik config:
+
+   ```bash
+   export TF_VAR_authentik_token='<token>'
+   make authentik-apply
+   ```
+
+   This runs Terraform, creates the OAuth/OIDC resources, writes client credentials into Kubernetes Secrets, and restarts the workloads that consume those Secrets.
+
+`make down` removes local Terraform state because the cluster, Authentik database, and Kubernetes Secrets are also destroyed. The provider lock file is intentionally kept.
 
 ## Terraform Involvement
-
-Terraform is intended to configure Authentik after the service exists.
 
 The files under `terraform/` define Authentik resources such as:
 
@@ -71,55 +109,46 @@ The files under `terraform/` define Authentik resources such as:
 - generated client secrets
 - Kubernetes Secrets containing OAuth client credentials
 
-In plain terms:
+Terraform currently writes:
 
-1. Helmfile installs the Authentik service.
-2. You create or provide an Authentik API token.
-3. Terraform connects to Authentik using that token.
-4. Terraform creates SSO integrations for services like Grafana and Headlamp.
-5. Terraform writes the generated client credentials back into Kubernetes Secrets.
-6. Helm values can later reference those Secrets to enable OIDC login.
+- `grafana-oauth-secret` in the `monitoring` namespace
+- `headlamp-oauth-secret` in the `kube-system` namespace
 
-This keeps SSO configuration reproducible instead of relying on hand-clicked console setup.
+The Authentik API token is only for Terraform to administer Authentik. The generated OAuth client IDs and secrets are what integrated apps use to authenticate themselves to Authentik during login.
 
-## Current Short-Lived Cluster Reality
+## Current Integrations
 
-Right now the cluster is designed to be turned on briefly and torn down with no meaningful persistence across sessions.
+Grafana works as the first native OIDC integration.
 
-That matters because Authentik stores its state in Postgres. If the database does not persist, then Authentik users, applications, providers, groups, tokens, and flows also disappear.
+Terraform creates the Grafana OAuth provider/application in Authentik and writes `grafana-oauth-secret`. The Grafana chart then reads that Secret through environment variables:
 
-For the current phase, Authentik should be treated as a learning spike:
+```text
+GF_AUTH_GENERIC_OAUTH_CLIENT_ID
+GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET
+```
 
-- deploy it
-- poke around the UI
-- wire one low-stakes service
-- learn the OIDC flow
-- make the setup repeatable
+The browser-facing authorization URL uses `http://authentik.home`, while Grafana's server-side token and userinfo URLs use the in-cluster Authentik service DNS name. This is necessary because the browser can resolve `.home` names through Pi-hole, but pods should use Kubernetes DNS for service-to-service calls.
 
-Do not make normal cluster access depend on Authentik yet.
+Headlamp was explored but is not considered working as a simple Authentik SSO integration.
 
-## When To Implement For Real
+Unlike Grafana, Headlamp's OIDC mode is tied to Kubernetes API authentication. Authentik can complete the login flow, but the Kubernetes API server must also trust Authentik as an OIDC issuer and RBAC must be configured for Authentik users or groups. Without that deeper Kubernetes OIDC setup, Headlamp returns to its login screen. For now, keep Headlamp's existing token/in-cluster access model or protect it later with an ingress-level auth gate instead of native OIDC.
 
-Wait until the hardware setup is in place before making Authentik the front door.
+## Other SSO Candidates
 
-Good signs that it is time:
+Good native OIDC candidates:
 
-- the cluster has stable nodes
-- Longhorn or another storage layer persists across restarts
-- Postgres data survives cluster cycles
-- `.home` DNS records are stable
-- Traefik ingress is the normal access path
-- SOPS age keys are backed up
-- restore procedures are at least lightly tested
+- Runner, because it has a browser-facing UI for running approved jobs. Authentik could provide login, and Runner could authorize actions based on groups such as `runner-users` or `homelab-admins`.
+- Django, because it has a browser-facing admin interface and Django has mature OIDC/social-auth libraries. Authentik groups could map to Django staff, superuser, or app-specific permissions.
+- Grafana role mapping, using Authentik groups to assign Grafana Admin, Editor, or Viewer. Grafana already supports Authentik login; role mapping would make authorization less manual.
+- Home Assistant only after checking its auth model carefully; it has its own user/session system and may not be worth forcing early.
 
-At that point Authentik becomes worth the complexity because it can survive long enough to be useful.
+The `api` service is not a good first SSO target because it does not currently expose a frontend login surface. It may still need auth later for API clients or service-to-service calls, but Runner and Django are better next steps for user-facing SSO.
 
-## Recommended Implementation Path
+Good ingress-gated candidates:
 
-1. Keep the current Helmfile release as WIP.
-2. Move Authentik from NodePort to Traefik ingress when DNS is stable.
-3. Decide which service should be the first OIDC client, probably Grafana.
-4. Make Terraform create the Authentik provider and application for that service.
-5. Store generated client credentials in Kubernetes Secrets.
-6. Update the service Helm values to read those credentials.
-7. Repeat for Headlamp only if Headlamp stays in the default install.
+- Prometheus, because it has little useful built-in auth in this setup.
+- Longhorn UI, because it is an admin surface that should not be casually exposed.
+- Pi-hole admin, if you want Authentik to gate access before Pi-hole's own login.
+- Headlamp, if you want SSO as an access gate without making Authentik a Kubernetes API identity provider.
+
+The ingress-gated pattern protects access before traffic reaches the app. It does not necessarily make the app aware of the Authentik user. Native OIDC is better when the app needs user identity, roles, or per-user audit behavior.

--- a/scripts/apply-authentik-terraform.sh
+++ b/scripts/apply-authentik-terraform.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+authentik_url="http://authentik.home"
+
+wait_for_url() {
+  local url="$1"
+
+  echo "Waiting for ${url}..."
+  for ((attempt = 1; attempt <= 60; attempt++)); do
+    if curl -fsS --max-time 5 "$url" >/dev/null; then
+      return
+    fi
+    sleep 5
+  done
+
+  echo "error: ${url} did not become reachable" >&2
+  exit 1
+}
+
+if [[ -z "${TF_VAR_authentik_token:-}" ]]; then
+  cat <<'MSG'
+Skipping Authentik Terraform: TF_VAR_authentik_token is not set.
+Finish Authentik initial setup, create an API token, then run:
+  export TF_VAR_authentik_token='<token>'
+  make authentik-apply
+MSG
+  exit 0
+fi
+
+if ! command -v terraform >/dev/null 2>&1; then
+  echo "error: terraform is required when TF_VAR_authentik_token is set" >&2
+  exit 1
+fi
+
+echo "Waiting for Authentik server..."
+kubectl -n kube-system wait --for=condition=available deployment/traefik --timeout=300s
+kubectl -n authentik wait --for=condition=available deployment/authentik-server --timeout=300s
+wait_for_url "$authentik_url"
+
+echo "Applying Authentik Terraform..."
+terraform -chdir="$repo_root/terraform" init -backend=false
+terraform -chdir="$repo_root/terraform" apply -auto-approve
+
+echo "Restarting Grafana to pick up OAuth credentials..."
+if kubectl -n monitoring get deployment -l app.kubernetes.io/name=grafana -o name | grep -q .; then
+  kubectl -n monitoring rollout restart deployment -l app.kubernetes.io/name=grafana
+  kubectl -n monitoring rollout status deployment -l app.kubernetes.io/name=grafana --timeout=180s
+else
+  echo "Grafana deployment not found; skipping rollout restart."
+fi
+
+echo "Restarting Headlamp to pick up OAuth credentials..."
+if kubectl -n kube-system get deployment headlamp >/dev/null 2>&1; then
+  kubectl -n kube-system rollout restart deployment/headlamp
+  kubectl -n kube-system rollout status deployment/headlamp --timeout=180s
+else
+  echo "Headlamp deployment not found; skipping rollout restart."
+fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -75,6 +75,8 @@ create_namespace metallb-system
 echo "Running Helmfile infra bootstrap..."
 "$repo_root/scripts/run-with-service-status.sh" bootstrap=infra -- helmfile sync --selector bootstrap=infra
 
+"$repo_root/scripts/apply-authentik-terraform.sh"
+
 wait_for_registry
 build_and_push_local_apps
 

--- a/services/authentik/values.yaml
+++ b/services/authentik/values.yaml
@@ -14,11 +14,15 @@ server:
   replicas: 1
 
   service:
-    type: NodePort
-    nodePort: 30080
+    type: ClusterIP
 
   ingress:
-    enabled: false
+    enabled: true
+    ingressClassName: traefik
+    hosts:
+      - authentik.home
+    path: /
+    pathType: Prefix
 
 worker:
   replicas: 1

--- a/services/headlamp/values.yaml
+++ b/services/headlamp/values.yaml
@@ -13,9 +13,14 @@ ingress:
 
 config:
   pluginsDir: ""
-
-extraArgs:
-  - "-insecure"
+  oidc:
+    secret:
+      create: false
+    callbackURL: http://headlamp.home/oidc-callback
+    externalSecret:
+      enabled: true
+      # Created by terraform/authentik.tf as kubernetes_secret_v1.headlamp_oauth.
+      name: headlamp-oauth-secret
 
 clusterRoleBinding:
   create: true

--- a/services/mosquitto/values.yaml
+++ b/services/mosquitto/values.yaml
@@ -1,19 +1,75 @@
-persistence:
-  enabled: true
-  storageClass: longhorn
-  size: 1Gi # Just for config/logs, very small
+controllers:
+  main:
+    type: statefulset
+    replicas: 1
+    containers:
+      main:
+        image:
+          repository: eclipse-mosquitto
+          tag: 2.0.22
+          pullPolicy: IfNotPresent
+        args:
+          - mosquitto
+          - -c
+          - /mosquitto/config/mosquitto.conf
+        ports:
+          - name: mqtt
+            containerPort: 1883
+            protocol: TCP
+        probes:
+          liveness:
+            enabled: true
+            type: TCP
+          readiness:
+            enabled: true
+            type: TCP
+          startup:
+            enabled: true
+            type: TCP
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+
+defaultPodOptions:
+  securityContext:
+    fsGroup: 1883
+    fsGroupChangePolicy: OnRootMismatch
+
+configMaps:
+  config:
+    data:
+      mosquitto.conf: |
+        listener 1883 0.0.0.0
+        allow_anonymous true
+        persistence true
+        persistence_location /mosquitto/data/
+        log_dest stdout
 
 service:
-  type: ClusterIP # Only needs internal cluster access
-  port: 1883
+  main:
+    controller: main
+    type: ClusterIP
+    ports:
+      mqtt:
+        port: 1883
+        targetPort: 1883
+        protocol: TCP
 
-auth:
-  enabled: false # For homelab, no auth needed
-
-resources:
-  requests:
-    cpu: 50m
-    memory: 64Mi
-  limits:
-    cpu: 200m
-    memory: 256Mi
+persistence:
+  config:
+    type: configMap
+    identifier: config
+    globalMounts:
+      - path: /mosquitto/config/mosquitto.conf
+        subPath: mosquitto.conf
+  data:
+    type: persistentVolumeClaim
+    storageClass: longhorn
+    accessMode: ReadWriteOnce
+    size: 1Gi
+    globalMounts:
+      - path: /mosquitto/data

--- a/services/openthread-border-router/values.yaml
+++ b/services/openthread-border-router/values.yaml
@@ -1,0 +1,102 @@
+controllers:
+  main:
+    replicas: 1
+    strategy: Recreate
+    pod:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      nodeSelector:
+        smart-home: "true"
+    containers:
+      main:
+        image:
+          repository: ghcr.io/ownbee/hass-otbr-docker
+          tag: 0.3.0
+          pullPolicy: IfNotPresent
+        env:
+          DEVICE: /dev/ttyThread
+          BAUDRATE: "460800"
+          FLOW_CONTROL: "1"
+          OTBR_LOG_LEVEL: notice
+          OTBR_REST_PORT: "8081"
+          OTBR_WEB: "1"
+          OTBR_WEB_PORT: "8080"
+          FIREWALL: "1"
+          NAT64: "0"
+        ports:
+          - name: web
+            containerPort: 8080
+            protocol: TCP
+          - name: rest
+            containerPort: 8081
+            protocol: TCP
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+              - IPC_LOCK
+              - NET_ADMIN
+        probes:
+          liveness:
+            enabled: true
+            type: TCP
+            spec:
+              initialDelaySeconds: 30
+          readiness:
+            enabled: true
+            type: TCP
+          startup:
+            enabled: true
+            type: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+
+persistence:
+  thread-adapter:
+    type: hostPath
+    hostPath: /dev/serial/by-id/REPLACE_WITH_THREAD_RCP_ADAPTER
+    hostPathType: CharDevice
+    globalMounts:
+      - path: /dev/ttyThread
+  tun:
+    type: hostPath
+    hostPath: /dev/net/tun
+    hostPathType: CharDevice
+    globalMounts:
+      - path: /dev/net/tun
+  data:
+    type: persistentVolumeClaim
+    storageClass: longhorn
+    accessMode: ReadWriteOnce
+    size: 1Gi
+    globalMounts:
+      - path: /data
+
+service:
+  main:
+    controller: main
+    type: ClusterIP
+    ports:
+      web:
+        port: 8080
+        protocol: HTTP
+      rest:
+        port: 8081
+        protocol: HTTP
+
+ingress:
+  main:
+    className: traefik
+    hosts:
+      - host: openthread.home
+        paths:
+          - path: /
+            pathType: Prefix
+            service:
+              identifier: main
+              port: web

--- a/services/prometheus/values.yaml
+++ b/services/prometheus/values.yaml
@@ -37,11 +37,47 @@ grafana:
   service:
     type: ClusterIP
     port: 3000
+  envValueFrom:
+    # Created by terraform/authentik.tf as kubernetes_secret_v1.grafana_oauth.
+    GF_AUTH_GENERIC_OAUTH_CLIENT_ID:
+      secretKeyRef:
+        name: grafana-oauth-secret
+        key: client_id
+        optional: true
+    GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET:
+      secretKeyRef:
+        name: grafana-oauth-secret
+        key: client_secret
+        optional: true
   ingress:
     enabled: true
     ingressClassName: traefik
     hosts:
       - grafana.home
+  grafana.ini:
+    server:
+      root_url: http://grafana.home
+    users:
+      allow_sign_up: false
+      allow_password_change: false
+    security:
+      disable_initial_admin_password_change: true
+    auth:
+      disable_login_form: false
+      disable_signout_menu: false
+      allow_user_sign_up: false
+      allow_user_org_create: false
+    auth.anonymous:
+      enabled: false
+      org_role: Viewer
+    auth.generic_oauth:
+      enabled: true
+      name: Authentik
+      allow_sign_up: true
+      scopes: openid email profile
+      auth_url: http://authentik.home/application/o/authorize/
+      token_url: http://authentik-server.authentik.svc.cluster.local/application/o/token/
+      api_url: http://authentik-server.authentik.svc.cluster.local/application/o/userinfo/
   additionalDataSources:
     - name: Loki
       type: loki

--- a/services/zigbee2mqtt/values.yaml
+++ b/services/zigbee2mqtt/values.yaml
@@ -1,0 +1,135 @@
+controllers:
+  main:
+    replicas: 1
+    strategy: Recreate
+    pod:
+      nodeSelector:
+        smart-home: "true"
+    containers:
+      main:
+        image:
+          repository: koenkk/zigbee2mqtt
+          tag: 2.10.1
+          pullPolicy: IfNotPresent
+        env:
+          ZIGBEE2MQTT_DATA: /app/data
+          TZ: America/Los_Angeles
+        ports:
+          - name: http
+            containerPort: 8080
+            protocol: TCP
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+              - SYS_ADMIN
+        probes:
+          liveness:
+            enabled: true
+            type: HTTP
+          readiness:
+            enabled: true
+            type: HTTP
+          startup:
+            enabled: true
+            type: HTTP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+    initContainers:
+      init-config:
+        image:
+          repository: mikefarah/yq
+          tag: 4.45.1
+          pullPolicy: IfNotPresent
+        command:
+          - /bin/sh
+          - -c
+        args:
+          - |
+            if [ ! -f /app/data/configuration.yaml ]; then
+              cp /configmap/configuration.yaml /app/data/configuration.yaml
+            fi
+        securityContext:
+          runAsUser: 0
+
+configMaps:
+  config:
+    data:
+      configuration.yaml: |
+        homeassistant:
+          enabled: true
+        permit_join: false
+        mqtt:
+          server: mqtt://mosquitto.home-automation.svc.cluster.local:1883
+        serial:
+          port: /dev/ttyZigbee
+        frontend:
+          enabled: true
+          port: 8080
+          url: http://zigbee2mqtt.home
+        advanced:
+          channel: 15
+          log_output:
+            - console
+          log_level: info
+          last_seen: ISO_8601_local
+          network_key: GENERATE
+
+service:
+  main:
+    controller: main
+    type: ClusterIP
+    ports:
+      http:
+        port: 8080
+        protocol: HTTP
+
+ingress:
+  main:
+    className: traefik
+    hosts:
+      - host: zigbee2mqtt.home
+        paths:
+          - path: /
+            pathType: Prefix
+            service:
+              identifier: main
+              port: http
+          - path: /api
+            pathType: Prefix
+            service:
+              identifier: main
+              port: http
+
+persistence:
+  config:
+    type: configMap
+    identifier: config
+    globalMounts:
+      - path: /configmap/configuration.yaml
+        subPath: configuration.yaml
+  data:
+    type: persistentVolumeClaim
+    storageClass: longhorn
+    accessMode: ReadWriteOnce
+    size: 2Gi
+    globalMounts:
+      - path: /app/data
+  zigbee-adapter:
+    type: hostPath
+    hostPath: /dev/serial/by-id/REPLACE_WITH_ZIGBEE_ADAPTER
+    hostPathType: CharDevice
+    globalMounts:
+      - path: /dev/ttyZigbee
+  run-udev:
+    type: hostPath
+    hostPath: /run/udev
+    hostPathType: Directory
+    globalMounts:
+      - path: /run/udev
+        readOnly: true

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,73 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/goauthentik/authentik" {
+  version     = "2026.2.0"
+  constraints = ">= 2026.2.0"
+  hashes = [
+    "h1:Hg5gBZc/mPbMwH3r5AVbDycUFoeh1LlHtAvVKsnruTY=",
+    "h1:On3/Zzv3W72aGsJ4AhW/tnpi4hvq9cxwgf7tF6Tg+a4=",
+    "h1:pum2uBRNDUjPeP9aYszm+6GU+K7tZIpbbLrsN39l8iw=",
+    "h1:zacZCsqLyCstv+qE+VhFvwCIGLQEdNBsMIM7r9umUSQ=",
+    "zh:00c44e8ee842e75de9cc4fd6193b10258d1dc840e5be4aaaf118ffc180dceee0",
+    "zh:13057f08bce3b63613e1be3997dd454ff9568c569dd983987b1550280fbe3d01",
+    "zh:410a1ff2ae4647cc0ab37894f81e4d474b588a0a7f005d05d55e8c3a40978dd2",
+    "zh:43830834d12b3c0eeabe397842f82ca3a6b58a5bc8dd837d55b821419b55ed61",
+    "zh:56eaedd196ed7c4003cee0434b891b38242b4fde2031978d0ddcfdf6e16ee5ad",
+    "zh:5b3c10bb63c3c215ed9e0918e5808b240e3f2ee8248d10cd4d824a4998a213c5",
+    "zh:99c14891bcb92a6b21ef4c0e60f6c0df23e3452808f3eefd67cde78d132c80d9",
+    "zh:9a32cdda9f939f8484e27d4200d004c44f016fe97579a111201083f4beea78e8",
+    "zh:ae5086816144f68de9a0002e7696321169a71473f9d161793f4ae996388f56de",
+    "zh:bd09409dd34608a4ef3ea80cfc5e397268e7872f2e84c1ccdc9b5698e36ddad5",
+    "zh:be7af8b9eb61b0eb5053f14360e5a68caeb32c115efe8e1b583f2e7c91352a2a",
+    "zh:e11726812a1b2caf6b6784a3d074d1f50e3d406e9629c02096a001e5a5979331",
+    "zh:e39183d10d8158ccab51208f4f727c7419b1b1e596f4feb23dc42aebb36d01e3",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "3.1.0"
+  constraints = ">= 3.1.0"
+  hashes = [
+    "h1:1/6H+t6GiaiWZfiKJaMkRecN+6LEvvLF9VPJArSTmC8=",
+    "h1:5gfiefKQFeADMtUj9NtnpQBe6GeUTJQ/MBpSwWu+pKY=",
+    "h1:G9QqKNpcztBRqrywtlNylFJSpGzDfRFtO8hcWLdkvRY=",
+    "h1:oodIAuFMikXNmEtil5MQgP4dfSctUBYQiGJfjbsF3NY=",
+    "zh:0215c5c60be62028c09a2f22458e89cda3ef5830a632299f1d401eb3538874b0",
+    "zh:09ebb9f442431e278a310a9423f32caf467cb4b3cad3fe59573ca71fa7b14e20",
+    "zh:0c4e5912f83bb35846ae0a9ae54fc320706ee61894cd21cc6b4181b1c5a2fa5c",
+    "zh:1678c982853ad461e65ccb5e79d585e13ed109dd47dab2a66d3a7a304faeef65",
+    "zh:1c050a5c15e330457a9c18caacf61a923c59d663e13f2962e4b32f04fef523a0",
+    "zh:2c55bcec83be58ec132c7cb0a1ac644758b800d794fdc636d53a0eada0358a3a",
+    "zh:a062bb0aa316c08d8460c66a5d68da71da40de5d3bc3b31abcf3a1a9a19650f1",
+    "zh:a26fdea0afaa9b247c73c0b42843ca51ba7db0ac2571f9d3d50dcabd20ca1b98",
+    "zh:c872c9385a78d502bf5823d61cd3bb0f9a0585030e025eb12585c83451beeaa1",
+    "zh:f180879af931182beee4c8c0d9dab62b81d86f17ddcbe3786ef4c7cec9163a4e",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f70f5789264069e0eef06f9b5d5fde955ef7206f7d446d1ce51a4c37a3f3e02f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = ">= 3.9.0"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "h1:UlBuNVuCGJ39tTv2c5gz2NRZnQbXfbIWbTzWcth5o74=",
+    "h1:lVDv+0AjDjrLfpmaJbWqUmIw/k3/AHXLc3N4m55SNdo=",
+    "h1:o0s5Mk9NXMP60nlheO1r0LsDGGratFb3oL0t7bD2QnM=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/terraform/authentik.tf
+++ b/terraform/authentik.tf
@@ -19,6 +19,10 @@ data "authentik_flow" "default_invalidation_flow" {
   slug = "default-provider-invalidation-flow"
 }
 
+data "authentik_certificate_key_pair" "default" {
+  name = "authentik Self-signed Certificate"
+}
+
 # Create OAuth2 Provider for Grafana
 resource "authentik_provider_oauth2" "grafana" {
   name               = "Grafana"
@@ -26,9 +30,10 @@ resource "authentik_provider_oauth2" "grafana" {
   client_secret      = random_password.grafana_secret.result
   authorization_flow = data.authentik_flow.default_authorization_flow.id
   invalidation_flow  = data.authentik_flow.default_invalidation_flow.id
+  signing_key        = data.authentik_certificate_key_pair.default.id
 
   allowed_redirect_uris = [
-    { matching_mode = "strict", url = "http://localhost:3000/login/generic_oauth" }
+    { matching_mode = "strict", url = "http://grafana.home/login/generic_oauth" }
   ]
 
   property_mappings = [
@@ -52,9 +57,10 @@ resource "authentik_provider_oauth2" "headlamp" {
   client_secret      = random_password.headlamp_secret.result
   authorization_flow = data.authentik_flow.default_authorization_flow.id
   invalidation_flow  = data.authentik_flow.default_invalidation_flow.id
+  signing_key        = data.authentik_certificate_key_pair.default.id
 
   allowed_redirect_uris = [
-    { matching_mode = "strict", url = "http://localhost:4466/oidc-callback" }
+    { matching_mode = "strict", url = "http://headlamp.home/oidc-callback" }
   ]
 
   property_mappings = [
@@ -85,7 +91,7 @@ data "authentik_property_mapping_provider_scope" "profile" {
 }
 
 # Store credentials in Kubernetes secrets
-resource "kubernetes_secret" "grafana_oauth" {
+resource "kubernetes_secret_v1" "grafana_oauth" {
   metadata {
     name      = "grafana-oauth-secret"
     namespace = "monitoring"
@@ -99,15 +105,18 @@ resource "kubernetes_secret" "grafana_oauth" {
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "headlamp_oauth" {
+resource "kubernetes_secret_v1" "headlamp_oauth" {
   metadata {
     name      = "headlamp-oauth-secret"
     namespace = "kube-system"
   }
 
   data = {
-    client_id     = authentik_provider_oauth2.headlamp.client_id
-    client_secret = authentik_provider_oauth2.headlamp.client_secret
+    OIDC_CLIENT_ID     = authentik_provider_oauth2.headlamp.client_id
+    OIDC_CLIENT_SECRET = authentik_provider_oauth2.headlamp.client_secret
+    OIDC_ISSUER_URL    = "http://authentik.home/application/o/headlamp/"
+    OIDC_SCOPES        = "openid email profile"
+    OIDC_CALLBACK_URL  = "http://headlamp.home/oidc-callback"
   }
 
   type = "Opaque"

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -2,15 +2,15 @@ terraform {
   required_providers {
     authentik = {
       source  = "goauthentik/authentik"
-      version = "~> 2024.10.0"
+      version = ">= 2026.2.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.23"
+      version = ">= 3.1.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.5"
+      version = ">= 3.9.0"
     }
   }
 }
@@ -18,7 +18,7 @@ terraform {
 # this would have to get manually created in the authentik console
 # one time after you spin up the cluster & all services
 provider "authentik" {
-  url   = "http://localhost:30080"
+  url   = "http://authentik.home"
   token = var.authentik_token
 }
 


### PR DESCRIPTION
### Description

Adds prepared protocol services and Authentik-backed SSO bootstrap for the homelab, including Grafana OIDC wiring and first-run documentation.

## Added

- Zigbee2MQTT and OpenThread Border Router service values plus hardware protocol notes
- Authentik Terraform apply helper and provider lock file

## Updated

- Grafana/AuthentiK OIDC configuration and startup/teardown lifecycle
- Authentik docs with initial setup, current integration status, and future SSO candidates