### PR TITLE
chore: add smart home device notes

### DIFF
--- a/apps/runner/README.md
+++ b/apps/runner/README.md
@@ -12,7 +12,7 @@ It can create one-off `Job` runs from those CronJob templates. The job definitio
 
 ## UI
 
-The runner UI is a dark, table-first dashboard at `/runner` (via Traefik). It loads jobs from `GET /api/jobs`, supports search and status filters, shows a per-job history sparkline, and opens a confirmation modal with a Grafana link after `POST /api/jobs/{app}/{name}/run`.
+The runner UI is a dashboard at `/runner` (via Traefik). It loads jobs from `GET /api/jobs`, supports search and status filters, shows a per-job history sparkline, and opens a confirmation modal with a Grafana link after `POST /api/jobs/{app}/{name}/run`.
 
 Click a job row to open its full run history. The list view still shows a short sparkline summary per job.
 
@@ -21,18 +21,6 @@ Click a job row to open its full run history. The list view still shows a short 
 - `GET /api/jobs` — app, name, schedule, status, last run, history
 - `GET /api/jobs/{app}/{name}/runs` — full run history for a job
 - `POST /api/jobs/{app}/{name}/run` — `{ runId, namespace, grafanaUrl }`
-- Legacy: `GET /api/runnables`, `POST /api/runnables/{namespace}/{cronjob_name}/runs`
-
-## Local Development
-
-```bash
-cd apps/runner
-uv sync
-uv run pytest   # enforces >=90% Python coverage on src/
-uv run uvicorn main:app --reload
-```
-
-Tests also sanity-check `src/static/*` and templates (design tokens, key UI behaviors, asset wiring).
 
 ## Grafana log links
 
@@ -42,7 +30,4 @@ Each run links to Loki with:
 - `pod` matched to every pod with `job-name=<Kubernetes Job name>` for that run
 - a time range from the Job start/finish times (with a small buffer)
 
-`RUNNER_LOKI_DATASOURCE_UID` must match the Loki datasource UID in Grafana
-(**Connections → Data sources → Loki**). Links use Explore `left=` (v0 array
-form: time range, datasource UID, LogQL with `namespace`, `container`, and `pod`
-labels). After changing link logic, rebuild and restart the **runner** deployment.
+`RUNNER_LOKI_DATASOURCE_UID` must match the Loki datasource UID in Grafana (**Connections → Data sources → Loki**). Links use Explore `left=` (v0 array form: time range, datasource UID, LogQL with `namespace`, `container`, and `pod` labels). After changing link logic, rebuild and restart the **runner** deployment.

--- a/notes/hardware/device_list.md
+++ b/notes/hardware/device_list.md
@@ -1,0 +1,127 @@
+# Smart Home Device List & Rough Pricing
+
+All prices are USD, rough street prices as of mid-2026. Local-first / no-cloud / no-subscription picks preferred throughout.
+
+## Access & Entry
+
+| Device                                            | Notes                                                                                                        | Qty | Unit | Subtotal |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | --- | ---- | -------- |
+| Yale Assure Lock 2 with Matter-over-Thread module | Front door deadbolt. Local control via Thread, no cloud.                                                     | 2   | $250 | $500     |
+| Konnected GDO blaQ (ratgdo board, productized)    | Local Home Assistant control of existing garage opener. Verify your opener is Security+ 2.0 (pre-late-2025). | 1   | $70  | $70      |
+| Reolink PoE Doorbell (POE, RTSP)                  | Wired PoE, integrates with HA + Frigate. No subscription.                                                    | 1   | $100 | $100     |
+| Subtotal                                          |                                                                                                              |     |      | $670     |
+
+## Cameras & NVR
+
+| Device                                          | Notes                                                                                                                                                                                          | Qty | Unit | Subtotal |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- | ---- | -------- |
+| Reolink RLC-820A 4K PoE camera                  | Front door, garage, side gate, backyard.                                                                                                                                                       | 4   | $90  | $360     |
+| Coral USB TPU                                   | Dedicated inference accelerator for Frigate. Offloads object detection from cluster nodes so camera ML doesn't compete with other workloads. Requires device plugin setup for K3s passthrough. | 1   | $60  | $60      |
+| Dedicated NVMe SSD for Frigate recordings (2TB) | Separate disk for continuous camera writes.                                                                                                                                                    | 1   | $150 | $150     |
+| Subtotal                                        |                                                                                                                                                                                                |     |      | $570     |
+
+## Presence, Motion & Contact Sensors
+
+| Device                                              | Notes                                                                                                                            | Qty | Unit | Subtotal |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | --- | ---- | -------- |
+| Aqara FP2 mmWave presence sensor                    | Living room, bedroom, office, any room needing stillness detection. FP400 is the 2026 upgrade if you want Thread-native (~$120). | 4   | $85  | $340     |
+| Aqara P1 / Hue motion sensor (PIR)                  | Hallways, closets, bathrooms, laundry. PIR is fine where you just need on/off.                                                   | 6   | $20  | $120     |
+| Aqara / Sonoff Zigbee door & window contact sensors | Exterior doors and windows.                                                                                                      | 12  | $12  | $144     |
+| Subtotal                                            |                                                                                                                                  |     |      | $604     |
+
+## Lighting & Switches
+
+| Device                                   | Notes                                                         | Qty | Unit | Subtotal |
+| ---------------------------------------- | ------------------------------------------------------------- | --- | ---- | -------- |
+| Inovelli Blue Series 2-1 (Zigbee) switch | Main living areas, dimmable rooms. LED bar for notifications. | 12  | $55  | $660     |
+| Inovelli Aux switch (for 3-ways)         | Companion switches in multi-way circuits.                     | 4   | $25  | $100     |
+| Subtotal                                 |                                                               |     |      | $760     |
+
+Smart bulbs intentionally omitted in favor of switches. Add color/temp bulbs later for specific accent fixtures if you want adaptive lighting.
+
+## Window Coverings
+
+| Device                                                                                | Notes                                                                                                          | Qty | Unit | Subtotal |
+| ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | --- | ---- | -------- |
+| IKEA PRAKTLYSING / TREDANSEN cellular blinds (Zigbee via DIRIGERA, or direct via Z2M) | Bedroom, west-facing windows for thermal automation, anywhere glare matters. Cheapest viable motorized option. | 6   | $180 | $1,080   |
+| IKEA DIRIGERA hub (optional; can pair direct to Z2M)                                  | Skip if pairing directly to your Zigbee coordinator.                                                           | 0   | $60  | $0       |
+| Subtotal                                                                              |                                                                                                                |     |      | $1,080   |
+
+Lutron Serena is the premium upgrade (~$350/window) if bedroom motor noise becomes an issue. SwitchBot Blind Tilt (~$70) is the retrofit option for existing horizontal blinds.
+
+## Climate & Environment
+
+| Device                                                 | Notes                                                                                                                                                                                                                                                                                                                    | Qty | Unit | Subtotal |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --- | ---- | -------- |
+| Thermostat (deferred)                                  | Zigbee/Thread thermostat options for US forced-air HVAC are weak as of 2026. Realistic paths: (1) keep dumb thermostat and let room temp sensors drive automations, (2) Ecobee with HACS local integration (~$230, WiFi but talks locally to HA), (3) wait for Matter thermostat support to mature. Not buying this yet. | 0   | $0   | $0       |
+| Aqara / Sonoff temperature & humidity sensors (Zigbee) | One per room. Drives blind automation, HVAC awareness.                                                                                                                                                                                                                                                                   | 8   | $15  | $120     |
+| Aqara TVOC air quality monitor (Zigbee)                | PM2.5, CO2, VOC. Useful during SoCal fire season. Local via Zigbee.                                                                                                                                                                                                                                                      | 2   | $70  | $140     |
+| Subtotal                                               |                                                                                                                                                                                                                                                                                                                          |     |      | $260     |
+
+## Water Protection
+
+| Device                                      | Notes                                              | Qty | Unit | Subtotal |
+| ------------------------------------------- | -------------------------------------------------- | --- | ---- | -------- |
+| Aqara Zigbee water leak sensor              | Under sinks, behind washer, water heater, fridge.  | 6   | $20  | $120     |
+| Aqara Smart Water Valve Controller (Zigbee) | Auto-close on leak detection. Zigbee, fully local. | 1   | $80  | $80      |
+| Subtotal                                    |                                                    |     |      | $200     |
+
+## Energy Monitoring
+
+| Device                                  | Notes                                                                        | Qty | Unit | Subtotal |
+| --------------------------------------- | ---------------------------------------------------------------------------- | --- | ---- | -------- |
+| IotaWatt (whole-home, local-first)      | Local-first, no cloud needed. Better fit than Emporia Vue given your stance. | 1   | $200 | $200     |
+| CT clamps for IotaWatt (14-channel kit) | Sized to your panel circuits.                                                | 1   | $150 | $150     |
+| Subtotal                                |                                                                              |     |      | $350     |
+
+## Cleaning Robots
+
+| Device                | Notes                                                                                                                     | Qty | Unit | Subtotal |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------- | --- | ---- | -------- |
+| Roborock S8 Pro Ultra | Vacuum + mop, self-empty dock. HA integration via `roborock` integration (local where supported). Refurb available ~$450. | 1   | $800 | $800     |
+| Subtotal              |                                                                                                                           |     |      | $800     |
+
+## Radio Coordinators
+
+| Device                                              | Notes                                                                                                  | Qty | Unit | Subtotal |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | --- | ---- | -------- |
+| Home Assistant Connect ZBT-1 (or Sonoff ZBDongle-E) | Concurrent Zigbee + Thread on a single stick. Pin to a specific K3s node via nodeSelector.             | 1   | $40  | $40      |
+| USB 2.0 extension cable (1m)                        | Moves coordinator away from host chassis to reduce 2.4 GHz RF interference. USB 2.0 only, not USB 3.0. | 1   | $8   | $8       |
+| Subtotal                                            |                                                                                                        |     |      | $48      |
+
+## Wall Display
+
+| Device                           | Notes                                                                                   | Qty | Unit | Subtotal |
+| -------------------------------- | --------------------------------------------------------------------------------------- | --- | ---- | -------- |
+| Lenovo Tab M11 (or similar)      | Wall-mounted HA dashboard with daily briefing view. Fully Kiosk Browser for kiosk mode. | 1   | $180 | $180     |
+| Wall mount + USB power cable run | Magnetic or recessed mount.                                                             | 1   | $40  | $40      |
+| Subtotal                         |                                                                                         |     |      | $220     |
+
+## Totals
+
+| Category                           | Subtotal |
+| ---------------------------------- | -------- |
+| Access & Entry                     | $670     |
+| Cameras & NVR                      | $570     |
+| Presence, Motion & Contact Sensors | $604     |
+| Lighting & Switches                | $760     |
+| Window Coverings                   | $1,080   |
+| Climate & Environment              | $260     |
+| Water Protection                   | $200     |
+| Energy Monitoring                  | $350     |
+| Cleaning Robots                    | $800     |
+| Radio Coordinators                 | $48      |
+| Wall Display                       | $220     |
+| Grand Total                        | $5,562   |
+
+## Notes on Sequencing
+
+If you want to phase this:
+
+1. Foundation first: Switches + contact sensors + leak sensors + locks. These are the highest daily-use, lowest-regret items.
+2. Presence and lighting automation: FP2s + motion sensors. Unlocks the bulk of the "magic" automations.
+3. Cameras and Frigate: Standalone project, can happen any time after networking is ready.
+4. Climate, blinds, energy: These layer on once room-level sensing is in place.
+5. Robots and wall display: Quality-of-life additions, not foundational.
+
+Quantities for sensors, switches, and contacts are placeholders. Walk the house, count actual switches, exterior doors, and rooms before ordering. Switch count is usually the biggest swing factor.

--- a/notes/hardware/device_protocols.md
+++ b/notes/hardware/device_protocols.md
@@ -4,13 +4,45 @@
 
 Smart home devices need a shared communication protocol to be controllable by a hub like Home Assistant. The main options:
 
-- Zigbee: mature, broad device support, mesh-based, local-only
-- Z-Wave: similar to Zigbee but proprietary, smaller ecosystem, longer range
-- Matter: newer standard backed by Apple/Google/Amazon, runs over Thread, WiFi, or Ethernet
-- Thread: network-layer mesh protocol (not a smart home standard itself, but Matter runs on it)
-- WiFi: high overhead, often cloud-dependent, avoid when possible
+- Zigbee: mature, broad device support, mesh-based, local-only. Operates on 2.4 GHz using the IEEE 802.15.4 radio standard.
+- Z-Wave: similar to Zigbee but proprietary, smaller ecosystem, longer range. Operates around 908 MHz in the US, avoiding the crowded 2.4 GHz band shared with WiFi and Bluetooth.
+- Thread: a mesh networking protocol that uses the same 802.15.4 radio as Zigbee but with an IPv6-based upper stack. Not a smart home standard itself, just the transport.
+- Matter: the application-layer standard backed by Apple, Google, and Amazon. Runs over Thread, WiFi, or Ethernet. The long-term direction for cross-vendor compatibility.
+- WiFi: high overhead, often cloud-dependent, avoid when possible.
 
-Devices need a protocol because they speak over radio, not IP. Something has to translate radio messages into something HA can understand. The protocol defines pairing, messaging, security, and how devices form a network.
+### How these protocols actually work
+
+At the bottom of any of these protocols is a radio chip transmitting and receiving packets over the air at a specific frequency. Zigbee, Thread, and Z-Wave are all low-power, low-bandwidth protocols designed for sensors and switches that send tiny messages occasionally — a temperature reading, a button press, a motion event. None of them are anything like WiFi in terms of throughput or power draw.
+
+Above the radio layer, each protocol defines how devices pair with each other, how they form a network, how messages are routed, and how they're secured. Devices need a protocol because they speak over radio, not IP. They aren't on your WiFi network, they don't have IP addresses (Thread devices do, but indirectly), and your computer has no way to hear them natively. Something has to bridge between the radio world and the IP world.
+
+### Why we need coordinator sticks
+
+Your computer doesn't have an 802.15.4 or Z-Wave radio built in. It has WiFi and Bluetooth, but those are completely different protocols on different hardware. To participate in a Zigbee, Thread, or Z-Wave network, you need to add the right radio to your machine — and the easiest way to do that is a USB stick called a "coordinator."
+
+A coordinator stick is a small computer with a dedicated radio chip (typically a Silicon Labs EFR32 or Texas Instruments CC2652 for 802.15.4 protocols). It handles the low-level radio timing, transmits and receives packets, manages the mesh network, and exposes a serial interface to the host computer over USB. From the host's perspective, the stick shows up as a serial device like `/dev/ttyUSB0` — basically a modem for the wireless protocol.
+
+The coordinator has a specific role in the network: it's the central node that maintains the network keys, handles pairing of new devices, and routes traffic. In Zigbee terms there's exactly one coordinator per network. End devices and routers talk to and through it.
+
+A practical gotcha: USB 3.0 ports emit broadband RF noise in the 2.4 GHz range, which is exactly where Zigbee and Thread operate. Plugging a coordinator directly into a USB 3.0 port or next to one degrades range and reliability significantly. The fix is a cheap USB 2.0 extension cable (not USB 3.0) that moves the stick a meter or so away from the host chassis.
+
+### Reading packets from the coordinator
+
+The coordinator handles the radio, but it doesn't know anything about your devices, what they mean, or how to expose them to Home Assistant. That's a separate software layer running on the host. For Zigbee, the standard choice is Zigbee2MQTT (Z2M):
+
+1. Z2M opens the serial connection to the coordinator stick
+2. Decodes incoming Zigbee packets and figures out which device they're from and what they mean (e.g., "this is a temperature reading of 21.5°C from the living room sensor")
+3. Publishes the decoded message to an MQTT topic like `zigbee2mqtt/living_room_sensor`
+
+MQTT is a generic pub/sub messaging protocol — Z2M doesn't know or care who's listening. A separate MQTT broker (Mosquitto) holds the messages and delivers them to anything subscribed. Home Assistant's MQTT integration subscribes to the relevant topics and updates its entities when new messages arrive.
+
+The full data flow:
+
+```
+sensor → radio packet → coordinator stick → serial/USB → Z2M container → MQTT broker → HA
+```
+
+Thread is structurally different. Thread devices are IPv6 endpoints — they have addresses and route packets through a Thread border router (OTBR), which bridges Thread and the regular IP network. HA's Matter integration talks to Thread devices over standard IP, no MQTT or serial passthrough required at the HA layer.
 
 ## The Two Chosen: Zigbee + Matter-over-Thread
 
@@ -73,7 +105,10 @@ Devices have no concept of nodes, containers, or clusters. They see only:
 - Other devices in the mesh
 
 The connection terminates at the radio. The radio lives in the USB stick. The USB stick is owned by a container running the protocol stack.
+
+```
 [Device] -> [Radio in USB stick] -> [Container running protocol software] -> [HA via IP]
+```
 
 ## The Containers
 


### PR DESCRIPTION
### Description

Adds smart home hardware planning notes and expands protocol guidance for Home Assistant device integrations.

## Added

- Hardware device list with rough pricing and rollout sequencing

## Updated

- Expanded Zigbee, Thread, Matter, MQTT, and coordinator notes
- Trimmed runner README wording and removed outdated local development details