### PR TITLE
feat: add homepage and improve local dev workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ Pinned local endpoints:
 - `apps.home` -> `192.168.76.245`
 - Pi-hole DNS service -> `192.168.76.246`
 
-Most browser-facing services resolve through Pi-hole and route through Traefik. The local registry uses a direct MetalLB LoadBalancer IP and bypasses Traefik. For app-owned workloads, prefer `ClusterIP` plus Traefik ingress. Use host-based routes for standalone UIs; use the workload chart's strip-prefix middleware for shared `apps.home` path routes.
+Most browser-facing services resolve through Pi-hole and route through Traefik. The local registry uses a direct MetalLB LoadBalancer IP and bypasses Traefik. For app-owned workloads, prefer `ClusterIP` plus Traefik ingress. Every app and service gets its own `<name>.home` host (Pi-hole wildcards `*.home` to Traefik); `apps.home` is the gethomepage dashboard. The workload chart's strip-prefix middleware remains available for path-based routing if ever needed.
 
 ## Services
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,8 @@ Prefer `make` targets over long hand-written commands. Useful tools include:
 ```bash
 make up                 # install K3s, bootstrap infra, build/push apps, sync apps
 make sync               # helmfile sync against an existing cluster
+make dev                # tilt up: live code reload + helm re-render for apps/*
+make dev-down           # tilt down: remove Tilt-managed app resources
 make down               # restore DNS and uninstall local K3s
 make validate-fast      # shellcheck and terraform fmt when tools exist
 make validate           # full local validation path mirroring CI

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,16 @@ sync:
 	@echo "Syncing Helmfile..."
 	@helmfile sync
 
+# Tilt dev loop for apps/* (live code reload, helm re-render, image rebuilds)
+.PHONY: dev
+dev:
+	@tilt up
+
+# stop the dev loop and remove Tilt-managed app resources (make sync restores them)
+.PHONY: dev-down
+dev-down:
+	@tilt down
+
 .PHONY: authentik-apply
 authentik-apply:
 	@./scripts/apply-authentik-terraform.sh
@@ -43,7 +53,7 @@ SHOWMIGRATIONS_EXTRAS := $(if $(filter showmigrations,$(_FIRST_GOAL)),$(wordlist
 
 STUBS_RAW := $(strip $(MIGRATE_EXTRAS) $(MIGRATIONS_EXTRAS) $(SHOWMIGRATIONS_EXTRAS))
 # Trailing words must be stub targets; exclude real Makefile goals so we never override them.
-_RESERVED_FOR_STUB := up sync authentik-apply down validate validate-fast update-charts django-manage image-build image-push image-build-push image-ref pihole-dns-enable pihole-dns-disable pihole-dns-status sops-age-generate migrate migrations showmigrations
+_RESERVED_FOR_STUB := up sync dev dev-down authentik-apply down validate validate-fast update-charts django-manage image-build image-push image-build-push image-ref pihole-dns-enable pihole-dns-disable pihole-dns-status sops-age-generate migrate migrations showmigrations
 STUBS := $(filter-out $(_RESERVED_FOR_STUB),$(STUBS_RAW))
 
 ifneq ($(STUBS),)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ up:
 	@sudo -v
 	@./scripts/run-step.sh "Running DNS bootstrap" -- bash ./scripts/setup-local-pihole-dns.sh disable
 	@./scripts/run-step.sh "Configuring registry access" -- bash ./scripts/setup-registry-home.sh
-	@./scripts/run-step.sh "Configuring ingress access" -- bash -c 'INGRESS_HOSTS="apps.home authentik.home grafana.home" bash ./scripts/setup-ingress-home.sh'
+	@./scripts/run-step.sh "Configuring ingress access" -- bash -c 'INGRESS_HOSTS="apps.home authentik.home grafana.home api.home django.home runner.home workload-chart.home" bash ./scripts/setup-ingress-home.sh'
 	@./scripts/run-step.sh "Writing K3s config" -- bash -c 'sudo mkdir -p /etc/rancher/k3s && sudo cp services/k3s/config.yaml /etc/rancher/k3s/config.yaml'
 	@./scripts/run-step.sh "Installing K3s" -- bash -c 'curl -sfL https://get.k3s.io | sh -'
 	@./scripts/run-step.sh "Waiting for K3s startup" -- sleep 10

--- a/README.md
+++ b/README.md
@@ -38,16 +38,17 @@ make pihole-dns-status
 
 ### Default Access
 
-| Service        | Access                                          | Credentials                                       |
-| -------------- | ----------------------------------------------- | ------------------------------------------------- |
-| Grafana        | [grafana.home](http://grafana.home)             | Authentik SSO (`auto_login`, login form disabled) |
-| Prometheus     | [prometheus.home](http://prometheus.home)       | —                                                 |
-| Home Assistant | [homeassistant.home](http://homeassistant.home) | Setup on first visit                              |
-| Authentik      | [authentik.home](http://authentik.home)         | Setup on first visit                              |
-| Longhorn UI    | [longhorn.home](http://longhorn.home)           | —                                                 |
-| Pi-hole        | [pihole.home/admin/](http://pihole.home/admin/) | admin / `pihole`                                  |
-| Apps           | [apps.home](http://apps.home)                   | —                                                 |
-| PostgreSQL     | `192.168.76.243:5432` / in-cluster service      | SOPS-managed postgres credentials                 |
+| Service        | Access                                                  | Credentials                                       |
+| -------------- | ------------------------------------------------------- | ------------------------------------------------- |
+| Homepage       | [apps.home](http://apps.home)                           | —                                                 |
+| Grafana        | [grafana.home](http://grafana.home)                     | Authentik SSO (`auto_login`, login form disabled) |
+| Prometheus     | [prometheus.home](http://prometheus.home)               | —                                                 |
+| Home Assistant | [homeassistant.home](http://homeassistant.home)         | Setup on first visit                              |
+| Authentik      | [authentik.home](http://authentik.home)                 | Setup on first visit                              |
+| Longhorn UI    | [longhorn.home](http://longhorn.home)                   | —                                                 |
+| Pi-hole        | [pihole.home/admin/](http://pihole.home/admin/)         | admin / `pihole`                                  |
+| Apps           | api.home, django.home, runner.home, workload-chart.home | —                                                 |
+| PostgreSQL     | `192.168.76.243:5432` / in-cluster service              | SOPS-managed postgres credentials                 |
 
 ## Services
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ make up
 # Re-sync after config changes
 make sync
 
+# Tilt dev loop for apps/* (live code reload, auto helm re-render)
+make dev
+
 # Run local validation
 make validate-fast
 make validate

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,59 +1,92 @@
-# Tilt dev loop for app-owned workloads.
-# This file intentionally targets `apps/*` releases only.
+# Tilt dev loop for app-owned workloads. Targets `apps/*` releases only.
+#
+# The dev loop, by file type:
+#   - App source (apps/<app>/src, api jobs/): live-synced into the running pod;
+#     uvicorn --reload (api/runner via values-dev.yaml), Django runserver
+#     autoreload, and a Go process restart pick the changes up in-place.
+#   - Dependency/build inputs (pyproject.toml, uv.lock, go.mod, go.sum,
+#     Dockerfile, entrypoint.sh): full image rebuild + redeploy. These are the
+#     build-context files not covered by a sync() step, so Tilt rebuilds
+#     automatically; ignore= keeps tests/values/secrets/.venv out of that set.
+#   - Helm inputs (helmfile.yaml, charts/workload/**, values*.yaml,
+#     secrets.sops.yaml): watched below, re-render via helmfile and redeploy.
+#   - Django migrations stay manual: the entrypoint only migrates an
+#     uninitialized DB; run `make migrate` to apply new migrations.
+
+load("ext://restart_process", "docker_build_with_restart")
 
 allow_k8s_contexts("default")
+
+APP_NAMES = ["django", "api", "runner", "workload-chart-example"]
 
 def app_image_ref(name):
     return "registry.home:5000/homelab/%s" % name
 
-def render_app_release(name):
-    return local("helmfile -l name=%s template" % name, quiet=True)
+# --- Helm rendering ---------------------------------------------------------
+# `local()` does not track which files helmfile reads, so watch them
+# explicitly; any change re-runs the Tiltfile, which re-renders the releases.
+watch_file("helmfile.yaml")
+for f in listdir("charts/workload", recursive=True):
+    watch_file(f)
+for name in APP_NAMES:
+    for dep in ["values.yaml", "values-dev.yaml.gotmpl", "secrets.sops.yaml"]:
+        path = "apps/%s/%s" % (name, dep)
+        if os.path.exists(path):
+            watch_file(path)
+watch_file("apps/runner/rbac.yaml")
 
-def app_release(name, context_dir, live_update_steps=[], links=[]):
+# One render for all app releases. `-e dev` activates the per-app
+# values-dev.yaml.gotmpl overlays (uvicorn --reload, single replica Go app).
+k8s_yaml(local("helmfile -e dev -l bootstrap=app template", quiet=True))
+
+# make up/sync apply this via a helmfile presync hook, but hooks don't run
+# under `helmfile template`, so apply it directly here.
+k8s_yaml("apps/runner/rbac.yaml")
+
+
+# --- Python apps -------------------------------------------------------------
+# Files in apps/<app>/ that are not image build inputs (Dockerfiles COPY
+# explicitly, so there is no .dockerignore); keep them out of Tilt's context
+# watch so editing them never triggers an image rebuild.
+PYTHON_NON_IMAGE_FILES = [
+    "tests",
+    ".venv",
+    "htmlcov",
+    ".pytest_cache",
+    ".coverage",
+    "**/__pycache__",
+    "*.pyc",
+    "values.yaml",
+    "values-dev.yaml.gotmpl",
+    "secrets.sops.yaml",
+    "README.md",
+]
+
+def python_app(name, sync_dirs, links=[], objects=[], extra_ignores=[]):
+    app_dir = "apps/%s" % name
     docker_build(
         app_image_ref(name),
-        context_dir,
-        dockerfile="%s/Dockerfile" % context_dir,
-        live_update=live_update_steps,
+        app_dir,
+        dockerfile="%s/Dockerfile" % app_dir,
+        live_update=[sync("%s/%s" % (app_dir, d), "/app/%s" % d) for d in sync_dirs],
+        ignore=PYTHON_NON_IMAGE_FILES + extra_ignores,
     )
-    k8s_yaml(render_app_release(name))
-    k8s_resource(name, links=links)
+    k8s_resource(name, links=links, objects=objects)
 
 
-# Django: live sync source changes, rebuild when dependency/build files change.
-# Django runs migrate on boot only when the DB is uninitialized (see django README).
-app_release(
+python_app(
     "django",
-    "apps/django",
-    live_update_steps=[
-        fall_back_on("apps/django/pyproject.toml"),
-        fall_back_on("apps/django/uv.lock"),
-        fall_back_on("apps/django/Dockerfile"),
-        fall_back_on("apps/django/entrypoint.sh"),
-        sync("apps/django/src", "/app/src"),
-        sync("apps/django/tests", "/app/tests"),
-    ],
+    sync_dirs=["src"],
+    extra_ignores=["src/staticfiles"],
     links=[
         link("http://apps.home/django/admin", "Django admin"),
         link("http://apps.home/django/healthz", "Health"),
     ],
 )
 
-
-# API: live sync source/test changes, rebuild when dependency/build/secret files change.
-app_release(
+python_app(
     "api",
-    "apps/api",
-    live_update_steps=[
-        fall_back_on("apps/api/pyproject.toml"),
-        fall_back_on("apps/api/uv.lock"),
-        fall_back_on("apps/api/Dockerfile"),
-        fall_back_on("apps/api/entrypoint.sh"),
-        fall_back_on("apps/api/secrets.sops.yaml"),
-        sync("apps/api/jobs", "/app/jobs"),
-        sync("apps/api/src", "/app/src"),
-        sync("apps/api/tests", "/app/tests"),
-    ],
+    sync_dirs=["src", "jobs"],
     links=[
         link("http://apps.home/api/docs", "API docs"),
         link("http://apps.home/api/healthz", "Health"),
@@ -61,36 +94,50 @@ app_release(
     ],
 )
 
-
-# Runner: live sync source/template/static changes, rebuild on dependency/build changes.
-app_release(
+python_app(
     "runner",
-    "apps/runner",
-    live_update_steps=[
-        fall_back_on("apps/runner/pyproject.toml"),
-        fall_back_on("apps/runner/uv.lock"),
-        fall_back_on("apps/runner/Dockerfile"),
-        fall_back_on("apps/runner/rbac.yaml"),
-        sync("apps/runner/src", "/app/src"),
-        sync("apps/runner/tests", "/app/tests"),
-    ],
+    sync_dirs=["src"],
     links=[
         link("http://apps.home/runner", "Runner"),
         link("http://apps.home/runner/healthz", "Health"),
     ],
+    objects=["runner:role", "runner:rolebinding"],
+    extra_ignores=["rbac.yaml"],
 )
 
 
-# workload-chart-example (Go): live sync source changes, rebuild on module/build changes.
-app_release(
-    "workload-chart-example",
-    "apps/workload-chart-example",
-    live_update_steps=[
-        fall_back_on("apps/workload-chart-example/go.mod"),
-        fall_back_on("apps/workload-chart-example/go.sum"),
-        fall_back_on("apps/workload-chart-example/Dockerfile"),
-        sync("apps/workload-chart-example/src", "/app/src"),
+# --- Go app ------------------------------------------------------------------
+# The runtime image only contains a compiled binary, so syncing source files
+# would do nothing. Instead: cross-compile locally on source/module changes,
+# sync the binary, and restart the process in-place (restart_process wrapper).
+local_resource(
+    "workload-chart-example-compile",
+    "cd apps/workload-chart-example && CGO_ENABLED=0 GOOS=linux GOARCH=amd64" +
+    " go build -o build/workload-chart-example ./src/main.go",
+    deps=[
+        "apps/workload-chart-example/src",
+        "apps/workload-chart-example/go.mod",
+        "apps/workload-chart-example/go.sum",
     ],
+)
+
+docker_build_with_restart(
+    app_image_ref("workload-chart-example"),
+    "apps/workload-chart-example",
+    dockerfile="apps/workload-chart-example/Dockerfile.tilt",
+    entrypoint=["/app/workload-chart-example"],
+    only=["build"],
+    live_update=[
+        sync(
+            "apps/workload-chart-example/build/workload-chart-example",
+            "/app/workload-chart-example",
+        ),
+    ],
+)
+
+k8s_resource(
+    "workload-chart-example",
+    resource_deps=["workload-chart-example-compile"],
     links=[
         link("http://apps.home/workload-chart/api/health/ready", "Health"),
         link("http://apps.home/workload-chart/api/metrics", "Metrics"),

--- a/Tiltfile
+++ b/Tiltfile
@@ -79,8 +79,8 @@ python_app(
     sync_dirs=["src"],
     extra_ignores=["src/staticfiles"],
     links=[
-        link("http://apps.home/django/admin", "Django admin"),
-        link("http://apps.home/django/healthz", "Health"),
+        link("http://django.home/admin", "Django admin"),
+        link("http://django.home/healthz", "Health"),
     ],
 )
 
@@ -88,9 +88,9 @@ python_app(
     "api",
     sync_dirs=["src", "jobs"],
     links=[
-        link("http://apps.home/api/docs", "API docs"),
-        link("http://apps.home/api/healthz", "Health"),
-        link("http://apps.home/api/metrics", "Metrics"),
+        link("http://api.home/docs", "API docs"),
+        link("http://api.home/healthz", "Health"),
+        link("http://api.home/metrics", "Metrics"),
     ],
 )
 
@@ -98,8 +98,8 @@ python_app(
     "runner",
     sync_dirs=["src"],
     links=[
-        link("http://apps.home/runner", "Runner"),
-        link("http://apps.home/runner/healthz", "Health"),
+        link("http://runner.home", "Runner"),
+        link("http://runner.home/healthz", "Health"),
     ],
     objects=["runner:role", "runner:rolebinding"],
     extra_ignores=["rbac.yaml"],
@@ -139,7 +139,7 @@ k8s_resource(
     "workload-chart-example",
     resource_deps=["workload-chart-example-compile"],
     links=[
-        link("http://apps.home/workload-chart/api/health/ready", "Health"),
-        link("http://apps.home/workload-chart/api/metrics", "Metrics"),
+        link("http://workload-chart.home/health/ready", "Health"),
+        link("http://workload-chart.home/metrics", "Metrics"),
     ],
 )

--- a/apps/api/.dockerignore
+++ b/apps/api/.dockerignore
@@ -1,6 +1,0 @@
-.coverage
-.pytest_cache/
-.venv/
-__pycache__/
-htmlcov/
-*.py[cod]

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -4,12 +4,12 @@ FastAPI application scaffold for homelab-owned HTTP APIs.
 
 After deployment, access the app through Traefik at:
 
-- `http://apps.home/api`
-- `http://apps.home/api/docs`
-- `http://apps.home/api/healthz`
-- `http://apps.home/api/readyz`
-- `http://apps.home/api/metrics`
-- `http://apps.home/api/reminders`
+- `http://api.home`
+- `http://api.home/docs`
+- `http://api.home/healthz`
+- `http://api.home/readyz`
+- `http://api.home/metrics`
+- `http://api.home/reminders`
 
 ## Directory Structure
 

--- a/apps/api/values-dev.yaml.gotmpl
+++ b/apps/api/values-dev.yaml.gotmpl
@@ -1,0 +1,17 @@
+# Dev-only overrides, active for `helmfile -e dev` (used by Tilt); renders to
+# {} otherwise. uvicorn --reload picks up files live-synced into /app/src.
+{{- if eq .Environment.Name "dev" }}
+args:
+  - uvicorn
+  - main:app
+  - --host
+  - 0.0.0.0
+  - --port
+  - "8000"
+  - --proxy-headers
+  - --reload
+  - --reload-dir
+  - /app/src
+{{- else }}
+{}
+{{- end }}

--- a/apps/api/values.yaml
+++ b/apps/api/values.yaml
@@ -1,7 +1,6 @@
 env:
   API_ENV: "production"
   API_LOG_LEVEL: "INFO"
-  API_ROOT_PATH: "/api"
   API_WAIT_FOR_DB: "true"
   DB_CONNECT_TIMEOUT: "5"
   DB_HOST: "postgres.postgres.svc.cluster.local"
@@ -37,16 +36,21 @@ service:
 ingress:
   enabled: true
   className: traefik
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "API"
+    gethomepage.dev/group: "Apps"
+    gethomepage.dev/icon: "fastapi.png"
+    gethomepage.dev/href: "http://api.home/docs"
+    gethomepage.dev/description: "FastAPI service"
   hosts:
-    - host: apps.home
+    - host: api.home
       paths:
-        - path: /api
+        - path: /
           pathType: Prefix
   traefik:
     stripPrefix:
-      enabled: true
-      prefixes:
-        - /api
+      enabled: false
 
 serviceMonitor:
   enabled: true

--- a/apps/django/README.md
+++ b/apps/django/README.md
@@ -7,13 +7,13 @@ Django app used as:
 
 After deployment in this homelab setup, access via your configured ingress path:
 
-- `http://apps.home/django/admin`
+- `http://django.home/admin`
 
 ## Authentik SSO
 
 With `DJANGO_SSO_ENABLED=true` (default in `values.yaml`), admin login redirects through Authentik. Only users in the `homelab-admins` group (`DJANGO_SSO_STAFF_GROUP`) can complete SSO; that group also grants Django staff and superuser.
 
-`make up` runs Terraform after the infra sync and writes `django-oauth-secret` before the app sync. Callback: `http://apps.home/django/sso/callback/`. Add homelab admins in the Authentik UI (group `homelab-admins`).
+`make up` runs Terraform after the infra sync and writes `django-oauth-secret` before the app sync. Callback: `http://django.home/sso/callback/`. Add homelab admins in the Authentik UI (group `homelab-admins`).
 
 ## Directory Structure
 

--- a/apps/django/src/core/settings.py
+++ b/apps/django/src/core/settings.py
@@ -84,8 +84,7 @@ TIME_ZONE = os.getenv("TZ", "UTC")
 USE_I18N = True
 USE_TZ = True
 
-# Served under the same URL prefix as the app (`/django` ingress path).
-STATIC_URL = "/django/static/"
+STATIC_URL = "/static/"
 STATIC_ROOT = BASE_DIR / "staticfiles"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
@@ -116,9 +115,9 @@ DJANGO_OIDC_JWKS_URL = os.getenv(
 DJANGO_OIDC_SCOPES = os.getenv("DJANGO_OIDC_SCOPES", "openid email profile")
 DJANGO_OIDC_CALLBACK_URL = os.getenv(
     "DJANGO_OIDC_CALLBACK_URL",
-    "http://apps.home/django/sso/callback/",
+    "http://django.home/sso/callback/",
 )
 DJANGO_SSO_STAFF_GROUP = os.getenv("DJANGO_SSO_STAFF_GROUP", "")
 DJANGO_SSO_SUPERUSER_GROUP = os.getenv("DJANGO_SSO_SUPERUSER_GROUP", "")
-LOGIN_URL = "/django/sso/login/"
-LOGIN_REDIRECT_URL = "/django/admin/"
+LOGIN_URL = "/sso/login/"
+LOGIN_REDIRECT_URL = "/admin/"

--- a/apps/django/src/core/sso.py
+++ b/apps/django/src/core/sso.py
@@ -79,7 +79,7 @@ def admin_login(
 
 def sso_login(request: HttpRequestWithSession) -> HttpResponse:
     if not sso_enabled():
-        return redirect("/django/admin/login/")
+        return redirect("/admin/login/")
 
     request.session[SESSION_NEXT_URL] = _safe_next_url(request)
     callback_url = settings.DJANGO_OIDC_CALLBACK_URL or request.build_absolute_uri(
@@ -90,17 +90,17 @@ def sso_login(request: HttpRequestWithSession) -> HttpResponse:
 
 def sso_callback(request: HttpRequestWithSession) -> HttpResponse:
     if not sso_enabled():
-        return redirect("/django/admin/login/")
+        return redirect("/admin/login/")
 
     client = _oauth().authentik
     try:
         token = client.authorize_access_token(request)
         userinfo = token.get("userinfo") or client.parse_id_token(request, token)
     except OAuthError:
-        return redirect("/django/admin/login/")
+        return redirect("/admin/login/")
 
     if not _sso_allowed(userinfo):
-        return redirect("/django/admin/login/")
+        return redirect("/admin/login/")
 
     user = _user_from_claims(userinfo)
     django_login(request, user, backend="django.contrib.auth.backends.ModelBackend")

--- a/apps/django/src/core/urls.py
+++ b/apps/django/src/core/urls.py
@@ -4,8 +4,8 @@ from django.urls import path
 
 from core import sso
 
-# Admin is only served under /django; default "View site" would link to http://apps.home/.
-admin.site.site_url = "/django/admin/"
+# Default "View site" would link to the host root, which has no page.
+admin.site.site_url = "/admin/"
 
 
 def healthz(_request):
@@ -13,10 +13,9 @@ def healthz(_request):
 
 
 urlpatterns = [
-    # Match ingress pathPrefix /django (no stripPrefix): same path inside the cluster.
-    path("django/admin/login/", sso.admin_login, name="admin_login"),
-    path("django/sso/login/", sso.sso_login, name="django_sso_login"),
-    path("django/sso/callback/", sso.sso_callback, name="django_sso_callback"),
-    path("django/admin/", admin.site.urls),
-    path("django/healthz", healthz),
+    path("admin/login/", sso.admin_login, name="admin_login"),
+    path("sso/login/", sso.sso_login, name="django_sso_login"),
+    path("sso/callback/", sso.sso_callback, name="django_sso_callback"),
+    path("admin/", admin.site.urls),
+    path("healthz", healthz),
 ]

--- a/apps/django/tests/test_core_coverage.py
+++ b/apps/django/tests/test_core_coverage.py
@@ -6,7 +6,7 @@ from django.test import override_settings
 
 
 def test_healthz_endpoint(client):
-    response = client.get("/django/healthz")
+    response = client.get("/healthz")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
 
@@ -119,6 +119,6 @@ def test_default_database_search_path_prefers_source():
 
 @override_settings(SESSION_ENGINE="django.contrib.sessions.backends.signed_cookies")
 def test_admin_append_slash_under_django_prefix(client):
-    response = client.get("/django/admin", HTTP_HOST="apps.home")
+    response = client.get("/admin", HTTP_HOST="django.home")
     assert response.status_code == 301
-    assert response["Location"] == "/django/admin/"
+    assert response["Location"] == "/admin/"

--- a/apps/django/tests/test_sso.py
+++ b/apps/django/tests/test_sso.py
@@ -30,28 +30,28 @@ class FakeAuthentikClient:
 
 
 def test_sso_disabled_redirects_to_local_admin_login(client):
-    response = client.get("/django/sso/login/")
+    response = client.get("/sso/login/")
 
     assert response.status_code == 302
-    assert response["Location"] == "/django/admin/login/"
+    assert response["Location"] == "/admin/login/"
 
 
 @override_settings(
     DJANGO_SSO_ENABLED=True,
     DJANGO_OIDC_CLIENT_ID="django",
     DJANGO_OIDC_CLIENT_SECRET="secret",
-    DJANGO_OIDC_CALLBACK_URL="http://apps.home/django/sso/callback/",
+    DJANGO_OIDC_CALLBACK_URL="http://django.home/sso/callback/",
     SESSION_ENGINE="django.contrib.sessions.backends.signed_cookies",
 )
 def test_admin_login_redirects_to_authentik_when_sso_enabled(client, monkeypatch):
     fake_client = FakeAuthentikClient()
     monkeypatch.setattr(sso, "_oauth", lambda: SimpleNamespace(authentik=fake_client))
 
-    response = client.get("/django/admin/login/?next=/django/admin/")
+    response = client.get("/admin/login/?next=/admin/")
 
     assert response.status_code == 302
     assert response["Location"] == "http://authentik.home/application/o/authorize/"
-    assert fake_client.callback_url == "http://apps.home/django/sso/callback/"
+    assert fake_client.callback_url == "http://django.home/sso/callback/"
 
 
 @override_settings(
@@ -63,7 +63,7 @@ def test_sso_enabled_requires_client_credentials(client):
     sso._oauth.cache_clear()
 
     with pytest.raises(ImproperlyConfigured):
-        client.get("/django/sso/login/")
+        client.get("/sso/login/")
 
 
 @override_settings(
@@ -95,13 +95,13 @@ def test_sso_callback_creates_django_user_and_logs_in(client, monkeypatch):
         ),
     )
     session = client.session
-    session[sso.SESSION_NEXT_URL] = "/django/admin/"
+    session[sso.SESSION_NEXT_URL] = "/admin/"
     session.save()
 
-    response = client.get("/django/sso/callback/")
+    response = client.get("/sso/callback/")
 
     assert response.status_code == 302
-    assert response["Location"] == "/django/admin/"
+    assert response["Location"] == "/admin/"
     assert "_auth_user_id" in client.session
 
 
@@ -129,10 +129,10 @@ def test_sso_callback_denies_users_without_admin_group(client, monkeypatch):
         ),
     )
 
-    response = client.get("/django/sso/callback/")
+    response = client.get("/sso/callback/")
 
     assert response.status_code == 302
-    assert response["Location"] == "/django/admin/login/"
+    assert response["Location"] == "/admin/login/"
     assert "_auth_user_id" not in client.session
 
 

--- a/apps/django/values.yaml
+++ b/apps/django/values.yaml
@@ -1,7 +1,7 @@
 env:
   DJANGO_DEBUG: "false"
   DJANGO_ALLOWED_HOSTS: "*"
-  DJANGO_CSRF_TRUSTED_ORIGINS: "http://apps.home"
+  DJANGO_CSRF_TRUSTED_ORIGINS: "http://django.home"
   DJANGO_SSO_ENABLED: "true"
   DJANGO_SSO_STAFF_GROUP: "homelab-admins"
   DJANGO_SSO_SUPERUSER_GROUP: "homelab-admins"
@@ -58,21 +58,21 @@ resources:
 
 readinessProbe:
   httpGet:
-    path: /django/healthz
+    path: /healthz
     port: http
     httpHeaders:
       - name: Host
-        value: apps.home
+        value: django.home
   periodSeconds: 10
   failureThreshold: 3
 
 livenessProbe:
   httpGet:
-    path: /django/healthz
+    path: /healthz
     port: http
     httpHeaders:
       - name: Host
-        value: apps.home
+        value: django.home
   periodSeconds: 20
   failureThreshold: 3
 
@@ -82,10 +82,17 @@ service:
 ingress:
   enabled: true
   className: traefik
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "Django Admin"
+    gethomepage.dev/group: "Apps"
+    gethomepage.dev/icon: "django.png"
+    gethomepage.dev/href: "http://django.home/admin"
+    gethomepage.dev/description: "Data admin and schema migrations"
   hosts:
-    - host: apps.home
+    - host: django.home
       paths:
-        - path: /django
+        - path: /
           pathType: Prefix
   traefik:
     stripPrefix:

--- a/apps/runner/tests/test_auth.py
+++ b/apps/runner/tests/test_auth.py
@@ -37,7 +37,7 @@ def sso_settings() -> Settings:
         oidc_userinfo_url="http://authentik.test/application/o/userinfo/",
         oidc_jwks_url="http://authentik.test/application/o/runner/jwks/",
         oidc_scopes="openid email profile groups",
-        oidc_callback_url="http://apps.home/runner/auth/callback",
+        oidc_callback_url="http://runner.home/auth/callback",
         session_secret_key="test-session-secret",
     )
 
@@ -80,7 +80,7 @@ def test_sso_login_and_callback_create_session(
     assert login_response.headers["location"] == (
         "http://authentik.home/application/o/authorize/"
     )
-    assert fake_oauth_client.redirect_uri == "http://apps.home/runner/auth/callback"
+    assert fake_oauth_client.redirect_uri == "http://runner.home/auth/callback"
     assert callback_response.status_code == 303
     assert callback_response.headers["location"] == "/runner/"
     assert home_response.status_code == 200

--- a/apps/runner/values-dev.yaml.gotmpl
+++ b/apps/runner/values-dev.yaml.gotmpl
@@ -1,0 +1,17 @@
+# Dev-only overrides, active for `helmfile -e dev` (used by Tilt); renders to
+# {} otherwise. uvicorn --reload picks up files live-synced into /app/src.
+{{- if eq .Environment.Name "dev" }}
+args:
+  - uvicorn
+  - main:app
+  - --host
+  - 0.0.0.0
+  - --port
+  - "8080"
+  - --proxy-headers
+  - --reload
+  - --reload-dir
+  - /app/src
+{{- else }}
+{}
+{{- end }}

--- a/apps/runner/values.yaml
+++ b/apps/runner/values.yaml
@@ -6,8 +6,9 @@ env:
   RUNNER_SSO_ALLOWED_GROUP: "homelab-admins"
   RUNNER_GRAFANA_BASE_URL: "http://grafana.home"
   RUNNER_CLUSTER_NAME: "homelab-prod"
-  # Grafana Loki datasource UID (Connections → Data sources → Loki → UID in the URL)
-  RUNNER_LOKI_DATASOURCE_UID: "P8E80F9AEF21F6940"
+  # Stable UID provisioned in services/prometheus/values.yaml additionalDataSources;
+  # survives cluster rebuilds (auto-generated UIDs do not).
+  RUNNER_LOKI_DATASOURCE_UID: "Loki"
 
 secretEnv:
   - name: RUNNER_OIDC_CLIENT_ID

--- a/apps/runner/values.yaml
+++ b/apps/runner/values.yaml
@@ -1,7 +1,6 @@
 env:
   RUNNER_ENVIRONMENT: "production"
   RUNNER_NAMESPACE: "apps"
-  RUNNER_URL_PREFIX: "/runner"
   RUNNER_SSO_ENABLED: "true"
   RUNNER_SSO_ALLOWED_GROUP: "homelab-admins"
   RUNNER_GRAFANA_BASE_URL: "http://grafana.home"
@@ -85,16 +84,20 @@ service:
 ingress:
   enabled: true
   className: traefik
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "Runner"
+    gethomepage.dev/group: "Apps"
+    gethomepage.dev/icon: "mdi-play-circle"
+    gethomepage.dev/description: "Kubernetes job runner"
   hosts:
-    - host: apps.home
+    - host: runner.home
       paths:
-        - path: /runner
+        - path: /
           pathType: Prefix
   traefik:
     stripPrefix:
-      enabled: true
-      prefixes:
-        - /runner
+      enabled: false
 
 serviceMonitor:
   enabled: true

--- a/apps/workload-chart-example/Dockerfile
+++ b/apps/workload-chart-example/Dockerfile
@@ -1,7 +1,9 @@
 FROM golang:1.25 AS builder
 
 WORKDIR /app
-COPY . .
+COPY go.mod go.sum ./
+RUN go mod download
+COPY src/ ./src/
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o workload-chart-example ./src/main.go
 

--- a/apps/workload-chart-example/Dockerfile.tilt
+++ b/apps/workload-chart-example/Dockerfile.tilt
@@ -1,0 +1,10 @@
+# Dev-only image used by the Tiltfile. The binary is cross-compiled on the
+# workstation by a Tilt local_resource and live-synced into the running
+# container, so this image only needs the runtime base.
+FROM debian:bookworm-slim
+WORKDIR /app
+COPY build/workload-chart-example /app/workload-chart-example
+
+EXPOSE 8080
+
+ENTRYPOINT ["/app/workload-chart-example"]

--- a/apps/workload-chart-example/README.md
+++ b/apps/workload-chart-example/README.md
@@ -20,7 +20,7 @@ This is a bare-bones example to test:
 - building and pushing an image to the local registry
 - scraping application metrics with Prometheus
 - collecting container stdout logs with Promtail/Loki
-- exposing an app-owned workload through Traefik on a shared `apps.home` host
+- exposing an app-owned workload through Traefik on its own `workload-chart.home` host
 
 ## Build and push
 
@@ -39,7 +39,7 @@ helmfile sync
 
 ## Ingress curl test
 
-This example is exposed at `http://apps.home/workload-chart/api`.
+This example is exposed at `http://workload-chart.home`.
 Traefik strips the `/workload-chart/api` prefix before forwarding to the pod, so the Go app can keep serving its internal root-level routes:
 
 - `GET /random`
@@ -47,19 +47,19 @@ Traefik strips the `/workload-chart/api` prefix before forwarding to the pod, so
 - `GET /health/live`
 - `GET /health/ready`
 
-`make up` runs `scripts/setup-ingress-home.sh`, which adds a persistent `/etc/hosts` entry for `apps.home` pointing at the pinned Traefik MetalLB IP. If you are syncing manually on a machine that has not run `make up`, run that script once or add the host entry yourself.
+`make up` runs `scripts/setup-ingress-home.sh`, which adds a persistent `/etc/hosts` entry for `workload-chart.home` pointing at the pinned Traefik MetalLB IP. If you are syncing manually on a machine that has not run `make up`, run that script once or add the host entry yourself.
 
 Then you can hit it directly:
 
 ```bash
-curl http://apps.home/workload-chart/api/random
+curl http://workload-chart.home/random
 ```
 
 You can also inspect health and metrics through the ingress path:
 
 ```bash
-curl http://apps.home/workload-chart/api/health/ready
-curl http://apps.home/workload-chart/api/metrics
+curl http://workload-chart.home/health/ready
+curl http://workload-chart.home/metrics
 ```
 
 ## Metrics and logs

--- a/apps/workload-chart-example/values-dev.yaml.gotmpl
+++ b/apps/workload-chart-example/values-dev.yaml.gotmpl
@@ -1,0 +1,10 @@
+# Dev-only overrides, active for `helmfile -e dev` (used by Tilt); renders to
+# {} otherwise. Single replica without HPA so live updates land predictably.
+{{- if eq .Environment.Name "dev" }}
+scale:
+  replicas: 1
+  autoscaling:
+    enabled: false
+{{- else }}
+{}
+{{- end }}

--- a/apps/workload-chart-example/values.yaml
+++ b/apps/workload-chart-example/values.yaml
@@ -34,20 +34,25 @@ livenessProbe:
 service:
   port: 8080
 
-# Available at http://apps.home/workload-chart/api
+# Available at http://workload-chart.home
 ingress:
   enabled: true
   className: traefik
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "Workload Example"
+    gethomepage.dev/group: "Apps"
+    gethomepage.dev/icon: "mdi-cube-outline"
+    gethomepage.dev/href: "http://workload-chart.home/health/ready"
+    gethomepage.dev/description: "Go reference workload"
   hosts:
-    - host: apps.home
+    - host: workload-chart.home
       paths:
-        - path: /workload-chart/api
+        - path: /
           pathType: Prefix
   traefik:
     stripPrefix:
-      enabled: true
-      prefixes:
-        - /workload-chart/api
+      enabled: false
 
 serviceMonitor:
   enabled: true

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -1,3 +1,13 @@
+# `default` is what make sync / CI use; `dev` is what Tilt uses. App releases
+# include apps/<app>/values-dev.yaml.gotmpl overlays, which render to {} in
+# every environment except dev (see Tiltfile).
+environments:
+  default: {}
+  dev: {}
+
+
+# helmfile v1 requires environments and releases in separate YAML parts
+---
 repositories:
   - name: prometheus-community
     url: https://prometheus-community.github.io/helm-charts
@@ -176,6 +186,7 @@ releases:
     chart: ./charts/workload
     values:
       - apps/workload-chart-example/values.yaml
+      - apps/workload-chart-example/values-dev.yaml.gotmpl
     needs:
       - monitoring/prometheus-operator
       - registry/registry
@@ -187,6 +198,7 @@ releases:
     chart: ./charts/workload
     values:
       - apps/api/values.yaml
+      - apps/api/values-dev.yaml.gotmpl
     secrets:
       - apps/api/secrets.sops.yaml
     needs:
@@ -202,6 +214,7 @@ releases:
     chart: ./charts/workload
     values:
       - apps/runner/values.yaml
+      - apps/runner/values-dev.yaml.gotmpl
     hooks:
       - events: ["presync"]
         showlogs: true

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -178,6 +178,18 @@ releases:
       - kube-system/traefik
     wait: true
 
+  - name: homepage
+    namespace: homepage
+    createNamespace: true
+    labels:
+      bootstrap: infra
+    chart: bjw-s/app-template
+    version: 4.6.2
+    values:
+      - services/homepage/values.yaml
+    needs:
+      - kube-system/traefik
+
   - name: workload-chart-example
     namespace: apps
     createNamespace: true

--- a/scripts/update-charts.sh
+++ b/scripts/update-charts.sh
@@ -24,7 +24,7 @@ yq_raw() { yq "$1" "$2" | sed 's/^"//; s/"$//'; }
 
 while read -r name && read -r url; do
   helm repo add "$name" "$url" --force-update &>/dev/null || true
-done < <(yq_raw '.repositories[] | (.name, .url)' "$HELMFILE")
+done < <(yq_raw '.repositories[]? | (.name, .url)' "$HELMFILE")
 helm repo update &>/dev/null
 echo
 
@@ -50,7 +50,7 @@ while read -r release_name && read -r chart && read -r version; do
   else
     current+=("$release_name" "$chart" "$version" "$latest")
   fi
-done < <(yq_raw '.releases[] | select(has("version")) | (.name, .chart, .version)' "$HELMFILE")
+done < <(yq_raw '.releases[]? | select(has("version")) | (.name, .chart, .version)' "$HELMFILE")
 
 # ── Output ────────────────────────────────────────────────────────────────────
 

--- a/services/authentik/values.yaml
+++ b/services/authentik/values.yaml
@@ -19,6 +19,15 @@ server:
   ingress:
     enabled: true
     ingressClassName: traefik
+    annotations:
+      gethomepage.dev/enabled: "true"
+      gethomepage.dev/name: "Authentik"
+      gethomepage.dev/group: "Infrastructure"
+      gethomepage.dev/icon: "authentik.png"
+      gethomepage.dev/description: "SSO identity provider"
+      # Status badge: pod lookup defaults to app.kubernetes.io/name=<ingress name>
+      # (authentik-server), which doesn't match the pod labels (authentik).
+      gethomepage.dev/app: "authentik"
     hosts:
       - authentik.home
     path: /

--- a/services/home-assistant/values.yaml
+++ b/services/home-assistant/values.yaml
@@ -19,6 +19,12 @@ ingress:
   enabled: true
   external: false
   className: traefik
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "Home Assistant"
+    gethomepage.dev/group: "Home Automation"
+    gethomepage.dev/icon: "home-assistant.png"
+    gethomepage.dev/description: "Smart home hub"
   hosts:
     - host: homeassistant.home
       paths:

--- a/services/homepage/values.yaml
+++ b/services/homepage/values.yaml
@@ -1,0 +1,146 @@
+# gethomepage dashboard at http://apps.home — discovers services from
+# ingresses annotated with gethomepage.dev/* (see other values files).
+# Requires sole ownership of the host: its frontend fetches data from
+# same-origin /api/* paths, so nothing else can claim a path prefix here
+# (apps live on their own <app>.home hosts).
+controllers:
+  main:
+    replicas: 1
+    serviceAccount:
+      identifier: homepage
+    containers:
+      main:
+        image:
+          repository: ghcr.io/gethomepage/homepage
+          tag: v1.13.2
+          pullPolicy: IfNotPresent
+        env:
+          # Host header allowlist; requests with other hosts get HTTP 400.
+          HOMEPAGE_ALLOWED_HOSTS: apps.home
+          LOG_LEVEL: info
+        ports:
+          - name: http
+            containerPort: 3000
+            protocol: TCP
+        # TCP probes: HTTP probes send the pod IP as Host header, which the
+        # HOMEPAGE_ALLOWED_HOSTS check rejects.
+        probes:
+          liveness:
+            enabled: true
+            type: TCP
+          readiness:
+            enabled: true
+            type: TCP
+          startup:
+            enabled: true
+            type: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 128Mi
+          limits:
+            cpu: 250m
+            memory: 512Mi
+
+serviceAccount:
+  homepage: {}
+
+rbac:
+  roles:
+    homepage:
+      type: ClusterRole
+      rules:
+        - apiGroups: [""]
+          resources: ["namespaces", "pods", "nodes"]
+          verbs: ["get", "list"]
+        - apiGroups: ["networking.k8s.io"]
+          resources: ["ingresses"]
+          verbs: ["get", "list"]
+        - apiGroups: ["metrics.k8s.io"]
+          resources: ["nodes", "pods"]
+          verbs: ["get", "list"]
+  bindings:
+    homepage:
+      type: ClusterRoleBinding
+      roleRef:
+        identifier: homepage
+      subjects:
+        - identifier: homepage
+
+configMaps:
+  config:
+    data:
+      settings.yaml: |
+        title: Homelab
+        hideVersion: true
+        layout:
+          Apps:
+          Monitoring:
+          Infrastructure:
+          Home Automation:
+      kubernetes.yaml: |
+        mode: cluster
+      services.yaml: |
+        # Populated automatically from ingresses with gethomepage.dev/* annotations.
+      widgets.yaml: |
+        - kubernetes:
+            cluster:
+              show: true
+              cpu: true
+              memory: true
+              showLabel: true
+              label: homelab
+            nodes:
+              show: false
+      bookmarks.yaml: |
+        - Cluster:
+            - Registry catalog:
+                - abbr: RG
+                  href: http://registry.home:5000/v2/_catalog
+      docker.yaml: ""
+
+persistence:
+  config:
+    type: configMap
+    identifier: config
+    globalMounts:
+      - path: /app/config/settings.yaml
+        subPath: settings.yaml
+      - path: /app/config/kubernetes.yaml
+        subPath: kubernetes.yaml
+      - path: /app/config/services.yaml
+        subPath: services.yaml
+      - path: /app/config/widgets.yaml
+        subPath: widgets.yaml
+      - path: /app/config/bookmarks.yaml
+        subPath: bookmarks.yaml
+      - path: /app/config/docker.yaml
+        subPath: docker.yaml
+  # homepage writes request logs under /app/config/logs; the configMap mount
+  # above is read-only, so give it a writable scratch dir.
+  logs:
+    type: emptyDir
+    globalMounts:
+      - path: /app/config/logs
+
+service:
+  main:
+    controller: main
+    type: ClusterIP
+    ports:
+      http:
+        port: 3000
+        targetPort: 3000
+        protocol: TCP
+
+ingress:
+  main:
+    className: traefik
+    hosts:
+      - host: apps.home
+        paths:
+          - path: /
+            pathType: Prefix
+            service:
+              identifier: main
+              port: http

--- a/services/longhorn/values.yaml
+++ b/services/longhorn/values.yaml
@@ -22,6 +22,14 @@ service:
 ingress:
   enabled: true
   ingressClassName: traefik
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "Longhorn"
+    gethomepage.dev/group: "Infrastructure"
+    gethomepage.dev/icon: "longhorn.png"
+    gethomepage.dev/description: "Cluster storage"
+    # Status badge: longhorn pods use legacy labels, not app.kubernetes.io/name.
+    gethomepage.dev/pod-selector: "app=longhorn-ui"
   host: longhorn.home
   path: /
   pathType: Prefix

--- a/services/pihole/values.yaml
+++ b/services/pihole/values.yaml
@@ -27,6 +27,13 @@ virtualHost: pihole.home
 ingress:
   enabled: true
   ingressClassName: traefik
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "Pi-hole"
+    gethomepage.dev/group: "Infrastructure"
+    gethomepage.dev/icon: "pi-hole.png"
+    gethomepage.dev/href: "http://pihole.home/admin"
+    gethomepage.dev/description: "DNS and ad blocking"
   path: /
   pathType: Prefix
   hosts:

--- a/services/prometheus/values.yaml
+++ b/services/prometheus/values.yaml
@@ -57,6 +57,12 @@ grafana:
   grafana.ini:
     server:
       root_url: http://grafana.home
+    # auto_login skips the login page, whose JS owns redirect handling when this
+    # toggle is on (default since 11.5) — deep links would land on the home page
+    # after SSO. Fall back to the backend cookie flow instead.
+    # https://github.com/grafana/grafana/issues/103567
+    feature_toggles:
+      useSessionStorageForRedirection: false
     users:
       allow_sign_up: false
       allow_password_change: false
@@ -75,7 +81,10 @@ grafana:
       name: Authentik
       allow_sign_up: true
       auto_login: true
-      scopes: openid email profile
+      scopes: openid email profile groups
+      # homelab-admins (the SSO admin group, same as django/runner) get org
+      # Admin; everyone else is Viewer, which Grafana 12 denies Explore.
+      role_attribute_path: contains(groups[*], 'homelab-admins') && 'Admin' || 'Viewer'
       auth_url: http://authentik.home/application/o/authorize/
       token_url: http://authentik-server.authentik.svc.cluster.local/application/o/token/
       api_url: http://authentik-server.authentik.svc.cluster.local/application/o/userinfo/

--- a/services/prometheus/values.yaml
+++ b/services/prometheus/values.yaml
@@ -21,6 +21,15 @@ prometheus:
   ingress:
     enabled: true
     ingressClassName: traefik
+    annotations:
+      gethomepage.dev/enabled: "true"
+      gethomepage.dev/name: "Prometheus"
+      gethomepage.dev/group: "Monitoring"
+      gethomepage.dev/icon: "prometheus.png"
+      gethomepage.dev/description: "Metrics and alerting"
+      # Status badge: pod lookup defaults to app.kubernetes.io/name=<ingress name>,
+      # which doesn't match this chart's pod labels.
+      gethomepage.dev/app: "prometheus"
     hosts:
       - prometheus.home
     paths:
@@ -52,6 +61,15 @@ grafana:
   ingress:
     enabled: true
     ingressClassName: traefik
+    annotations:
+      gethomepage.dev/enabled: "true"
+      gethomepage.dev/name: "Grafana"
+      gethomepage.dev/group: "Monitoring"
+      gethomepage.dev/icon: "grafana.png"
+      gethomepage.dev/description: "Dashboards and logs"
+      # Status badge: pod lookup defaults to app.kubernetes.io/name=<ingress name>,
+      # which doesn't match this chart's pod labels.
+      gethomepage.dev/app: "grafana"
     hosts:
       - grafana.home
   grafana.ini:

--- a/terraform/authentik.tf
+++ b/terraform/authentik.tf
@@ -59,7 +59,7 @@ module "grafana_oidc" {
   authorization_flow_id       = data.authentik_flow.default_authorization_flow.id
   invalidation_flow_id        = data.authentik_flow.default_invalidation_flow.id
   signing_key_id              = data.authentik_certificate_key_pair.default.id
-  property_mapping_ids        = local.oidc_property_mapping_ids
+  property_mapping_ids        = local.admin_oidc_property_mapping_ids
   kubernetes_secret_namespace = "monitoring"
   client_id_secret_key        = "client_id"
   client_secret_secret_key    = "client_secret"

--- a/terraform/authentik.tf
+++ b/terraform/authentik.tf
@@ -74,7 +74,7 @@ module "django_oidc" {
   source = "./modules/authentik_oidc_app"
 
   app_id                      = "django"
-  meta_launch_url             = "http://apps.home/django/admin/"
+  meta_launch_url             = "http://django.home/admin/"
   authorization_flow_id       = data.authentik_flow.default_authorization_flow.id
   invalidation_flow_id        = data.authentik_flow.default_invalidation_flow.id
   signing_key_id              = data.authentik_certificate_key_pair.default.id
@@ -82,12 +82,12 @@ module "django_oidc" {
   kubernetes_secret_namespace = "apps"
 
   allowed_redirect_uris = [
-    { matching_mode = "strict", url = "http://apps.home/django/sso/callback/" }
+    { matching_mode = "strict", url = "http://django.home/sso/callback/" }
   ]
 
   secret_data = {
     OIDC_SCOPES       = "openid email profile groups"
-    OIDC_CALLBACK_URL = "http://apps.home/django/sso/callback/"
+    OIDC_CALLBACK_URL = "http://django.home/sso/callback/"
   }
 }
 
@@ -95,7 +95,7 @@ module "runner_oidc" {
   source = "./modules/authentik_oidc_app"
 
   app_id                      = "runner"
-  meta_launch_url             = "http://apps.home/runner/"
+  meta_launch_url             = "http://runner.home/"
   authorization_flow_id       = data.authentik_flow.default_authorization_flow.id
   invalidation_flow_id        = data.authentik_flow.default_invalidation_flow.id
   signing_key_id              = data.authentik_certificate_key_pair.default.id
@@ -103,12 +103,12 @@ module "runner_oidc" {
   kubernetes_secret_namespace = "apps"
 
   allowed_redirect_uris = [
-    { matching_mode = "strict", url = "http://apps.home/runner/auth/callback" }
+    { matching_mode = "strict", url = "http://runner.home/auth/callback" }
   ]
 
   secret_data = {
     OIDC_SCOPES       = "openid email profile groups"
-    OIDC_CALLBACK_URL = "http://apps.home/runner/auth/callback"
+    OIDC_CALLBACK_URL = "http://runner.home/auth/callback"
   }
 
   generated_secret_keys = {


### PR DESCRIPTION
### Description

Adds a homepage dashboard service and improves the local dev experience with Tilt-specific values files and SSO integration updates across services.

## Added

- `services/homepage` deployed via helmfile with Authentik SSO wiring
- `values-dev.yaml.gotmpl` overrides and `Dockerfile.tilt` for local Tilt development

## Updated

- Tiltfile, Makefile, and runner/django/api charts for the new local dev workflow
- Prometheus, Pi-hole, Longhorn, and Home Assistant values