### PR TITLE
chore: document homelab GitOps workflows

### DIFF
--- a/notes/ideas/argo-cd.md
+++ b/notes/ideas/argo-cd.md
@@ -1,0 +1,264 @@
+# Argo CD and Future Homelab GitOps
+
+## Purpose
+
+Document whether Argo CD should eventually replace the current Helmfile deployment workflow when the homelab moves from ephemeral desktop K3s to a permanent Talos-based cluster.
+
+## Current Context
+
+The current project runs K3s locally on a personal desktop for development. `make up` installs K3s, `scripts/setup.sh` bootstraps infrastructure and applications, and `helmfile.yaml` defines the Helm repositories, releases, values, secrets, dependencies, and hooks.
+
+The future physical homelab is expected to use three mini-PCs with approximately 96 GB of total memory. Talos is a good candidate for those nodes because it is an immutable, Kubernetes-focused operating system with configuration managed through `talosctl` and machine configuration files.
+
+The current and future environments do not need to use the same cluster bootstrap mechanism:
+
+```text
+Current desktop:  K3s + Helmfile + Tilt + SOPS
+Future homelab:   Talos + Kubernetes + Helmfile or Argo CD + SOPS
+```
+
+The Talos design is a future infrastructure plan rather than the current implementation. The reference notes currently describe generated Talos configuration under `~/talos`, while the repository itself contains the K3s bootstrap path.
+
+## What Argo CD Is
+
+Argo CD is a Kubernetes controller and deployment system for GitOps. It watches a Git repository, renders the desired Kubernetes resources, compares them with the live cluster, and optionally synchronizes the cluster automatically.
+
+Argo CD is not an operating system, Kubernetes installer, image builder, secret manager, or Terraform replacement. It starts working after a Kubernetes API is available and Argo CD itself has been bootstrapped.
+
+The basic flow is:
+
+```text
+Git commit
+    |
+    v
+Argo CD fetches and renders the desired state
+    |
+    v
+Argo CD compares Git state with live Kubernetes state
+    |
+    v
+Argo CD applies changes and reports health/sync status
+```
+
+Argo CD normally refreshes Git repositories periodically. The default reconciliation interval is approximately two to three minutes, and Git webhooks can trigger an earlier refresh when the Argo CD API is reachable by the Git provider.
+
+## Argo CD and Helm Are Complementary
+
+This is not an Argo CD versus Helm decision.
+
+Helm answers:
+
+> How should this application be packaged and templated?
+
+Argo CD answers:
+
+> What should be running in the cluster, and does the live cluster match Git?
+
+A future stack could therefore be:
+
+```text
+Talos
+  └── Kubernetes
+        ├── Helm charts       -> package and render applications
+        ├── Argo CD           -> reconcile rendered resources from Git
+        ├── SOPS/External Secrets -> provide secrets
+        └── Terraform         -> manage external APIs such as Authentik
+```
+
+Argo CD can use Helm charts directly. Helm is primarily used to render the chart, while Argo CD manages synchronization and drift rather than relying on Helm's local release lifecycle.
+
+The more relevant choice is whether to keep Helmfile as the deployment orchestrator or eventually express the releases as native Argo CD `Application` resources.
+
+## What Argo CD Would Provide
+
+### Automatic synchronization
+
+After a commit is merged to the tracked branch, Argo CD can render and deploy the change without requiring a manual `helmfile sync` from the desktop.
+
+### Drift correction
+
+With automated self-healing enabled, Argo CD can detect manual changes made with `kubectl` and restore the Git-defined state. This makes the cluster a reconciled runtime rather than a system that depends on remembering to run deployment commands.
+
+### Resource pruning
+
+With automated pruning enabled, Argo CD can remove Kubernetes resources that were intentionally removed from Git. This is useful for maintaining a clean cluster, but it should be enabled only after the migration is understood because a bad commit can delete resources.
+
+### Deployment visibility
+
+Argo CD provides application-level sync status, health, history, rendered manifests, events, and failure details. This would make it easier to answer whether a Git commit was actually deployed and which resource prevented an application from becoming healthy.
+
+### Less dependence on the desktop
+
+The desktop would no longer need to have the cluster's administrative kubeconfig just to deploy ordinary changes. Argo CD would pull the repository and apply changes from inside the cluster.
+
+### Better multi-cluster support
+
+If the homelab eventually grows beyond one cluster, Argo CD can manage multiple Kubernetes destinations from a common Git structure. This is not necessary for the first physical cluster, but it is a useful future capability.
+
+## What Argo CD Would Replace
+
+If the project eventually moves to native Argo CD applications, the mapping would look like this:
+
+| Current workflow                         | Possible Argo CD workflow                                         |
+| ---------------------------------------- | ----------------------------------------------------------------- |
+| Helmfile release definitions             | Argo CD `Application` or `ApplicationSet` resources               |
+| Helmfile chart repositories and versions | Chart source fields on each `Application`                         |
+| Helmfile values files                    | Argo CD Helm `valueFiles` or values objects                       |
+| `helmfile sync` and `make sync`          | Automated Argo CD synchronization                                 |
+| Helmfile `needs` and ordering            | Sync waves plus resource health checks                            |
+| `createNamespace: true`                  | Namespace manifests or `CreateNamespace=true`                     |
+| Imperative Helmfile hooks                | Normal Kubernetes resources, Jobs, or carefully scoped Argo hooks |
+| Much of `scripts/setup.sh`               | Argo CD applications and dependency ordering                      |
+
+Helm itself would not necessarily be removed. The local `charts/workload` chart and third-party Helm charts could continue to be used.
+
+## What Argo CD Would Not Replace
+
+### Talos or K3s bootstrap
+
+Argo CD cannot install Talos, configure BIOS settings, provision mini-PCs, bootstrap the first Kubernetes control plane, or repair a cluster that has no functioning Kubernetes API. A one-time bootstrap process remains necessary.
+
+The future Talos machine configuration should be treated as a separate infrastructure layer managed through `talosctl`, Terraform, or another host-level workflow.
+
+### Image builds
+
+Argo CD deploys image references; it does not build application images. CI or a LAN-accessible build runner would still need to build and push images.
+
+The current workload chart defaults to the local `registry.home:5000` registry and a mutable `dev` tag. For a GitOps deployment, immutable tags or image digests are preferable. If GitHub-hosted CI cannot reach the LAN registry, the choices are a self-hosted LAN runner, a registry reachable by the cluster and CI, or a separate local-development image workflow.
+
+### Terraform and external APIs
+
+The Authentik Terraform configuration manages resources through the Authentik API after Authentik is running. Argo CD does not natively replace that workflow. Terraform can remain a separate Git-driven workflow, or a future Terraform controller/Crossplane setup could reconcile it inside Kubernetes.
+
+### Physical and network infrastructure
+
+Router settings, DHCP reservations, switch configuration, physical disks, BIOS settings, and workstation DNS are outside ordinary Argo CD management unless their vendors expose APIs that another infrastructure tool can manage.
+
+### Persistent data
+
+Git should describe how Postgres, Home Assistant, Longhorn, and other stateful services are deployed and backed up. It should not contain the actual application data. Persistent data requires backups and restore procedures rather than Git reconciliation.
+
+## SOPS and Secrets
+
+SOPS-encrypted files can remain in Git, including a public GitHub repository, as long as the encryption keys and plaintext values are never committed. The fact that a file is encrypted does not protect secrets that were previously committed in plaintext, so secret history and rotation still matter.
+
+The current Helmfile workflow understands entries such as:
+
+```yaml
+secrets:
+  - services/authentik/secrets.sops.yaml
+```
+
+Native Argo CD does not automatically understand Helmfile's `secrets` field or decrypt SOPS files by itself. Moving from Helmfile to native Argo CD would require one of these approaches:
+
+1. Keep Helmfile as an Argo CD Config Management Plugin that runs `helmfile template`, with Helmfile, Helm-secrets, SOPS, age, and the age key installed in the Argo repo-server environment.
+2. Use native Argo CD Applications with a SOPS integration such as KSOPS or an equivalent Helm-secrets integration.
+3. Use External Secrets Operator, storing only external-secret declarations in Git and keeping actual secret values in a password manager or other secret backend.
+4. Use Sealed Secrets or another controller-specific encrypted-secret format.
+
+The first option is a migration bridge, not necessarily the desired final architecture. It preserves Helmfile complexity and means that Helmfile hooks and dependency behavior still need careful treatment.
+
+The second option is more native to Argo CD but requires repository and repo-server configuration. The decryption key must be provisioned into the cluster or Argo repo-server separately from the public Git repository.
+
+## Git Repository Options
+
+The future Argo CD `Application` could track the public repository directly:
+
+```yaml
+repoURL: https://github.com/jyablonski/homelab.git
+targetRevision: main
+```
+
+Argo CD would periodically fetch `main`, notice a new commit, render the desired resources, and synchronize them if automated sync were enabled. A GitHub webhook could reduce the normal polling delay, but a LAN-only cluster would generally use outbound polling because GitHub cannot normally reach the cluster directly.
+
+The source does not have to be GitHub. A local Git server such as Gitea, GitLab, or a bare repository served over SSH or HTTPS would also work. The important requirement is that the Argo repo-server can reach the Git server.
+
+A working copy that exists only on the desktop is not sufficient because Argo CD runs inside the cluster and cannot access the desktop's filesystem. If the Git server itself runs inside the same cluster, it creates a bootstrap dependency: Argo CD cannot retrieve its source while that Git server is unavailable. A public or externally hosted repository avoids that circular dependency.
+
+## Pros and Cons
+
+### Advantages
+
+- Git commits can deploy automatically.
+- Manual changes can be detected and corrected.
+- The cluster does not depend on the desktop for routine deployments.
+- Application health and sync history are visible in one place.
+- Removed resources can be pruned automatically.
+- The same model can later manage multiple clusters.
+- CI does not need broad direct access to the Kubernetes API for deployment.
+
+### Disadvantages
+
+- Argo CD is another system to install, upgrade, secure, monitor, and recover.
+- The first bootstrap still requires an external or manual step.
+- Native migration from Helmfile requires work.
+- SOPS requires an Argo-compatible integration rather than working automatically.
+- Automated sync can deploy a bad Git commit quickly.
+- Automated pruning can delete resources if the Git change is wrong.
+- Argo CD does not solve image builds, Terraform, Talos, hardware, or data backups.
+- A cluster with Argo CD but no repository access cannot reconcile new changes.
+
+## When to Reach for Argo CD
+
+Argo CD becomes more valuable after the physical cluster exists and is expected to run continuously.
+
+Good reasons to adopt it would be:
+
+- Manually running `helmfile sync` is becoming tedious.
+- The cluster frequently drifts from the repository.
+- The desktop should not be required for deployment.
+- There are multiple people, environments, or clusters.
+- Application health and deployment history need to be visible.
+- Automatic recovery after manual changes or partial failures is valuable.
+- Image and configuration promotion are being driven through pull requests.
+
+Reasons to defer it would be:
+
+- The cluster is still ephemeral.
+- There is only one operator and one cluster.
+- `make sync` is simple enough.
+- Helmfile already provides the desired dependency and secret behavior.
+- The operational cost of adding Argo CD is greater than the value of automatic reconciliation.
+
+## Recommended Path
+
+### Now: keep the local project simple
+
+Continue using the current K3s-based desktop workflow with Helmfile, Tilt, and SOPS. This is a good fit for ephemeral development and avoids introducing Argo CD before there is a persistent cluster that benefits from reconciliation.
+
+### When the mini-PC cluster arrives: start with Talos and Helmfile
+
+Set up the three-node Talos cluster, validate Longhorn and the network model, and reuse the existing Helmfile values and charts where practical. This separates the operating-system migration from the deployment-controller migration.
+
+The cluster bootstrap should be documented and reproducible, but it does not need to be completely driven by Argo CD. Argo CD cannot bootstrap itself before Kubernetes exists.
+
+### Later: explore Argo CD if the need appears
+
+Install Argo CD after the Talos cluster is stable and evaluate it against the actual operational pain. Start with one or two non-critical applications and verify Git synchronization, drift correction, health reporting, and SOPS integration before migrating the whole homelab.
+
+If Argo CD proves useful, migrate Helmfile releases gradually into native Argo CD Applications. Keep Helm charts, values, and encrypted secrets in Git, replace imperative hooks with declarative resources where possible, and retain Helmfile for local development until the native Argo workflow is proven.
+
+The recommended sequence is therefore:
+
+```text
+Current desktop:
+  K3s + Helmfile + Tilt + SOPS
+
+Future physical cluster:
+  Talos + Kubernetes + Helmfile + SOPS
+
+Optional later evolution:
+  Talos + Kubernetes + Argo CD + Helm + SOPS integration
+```
+
+The goal is Git as the source of truth for desired configuration. Argo CD is one way to automate reconciliation of that truth, not a prerequisite for infrastructure as code.
+
+## References
+
+- [Argo CD Helm integration](https://argo-cd.readthedocs.io/en/stable/user-guide/helm/)
+- [Argo CD automated sync](https://argo-cd.readthedocs.io/en/stable/user-guide/auto_sync/)
+- [Argo CD webhook configuration](https://argo-cd.readthedocs.io/en/latest/operator-manual/webhook/)
+- [Argo CD sync waves](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/)
+- [Argo CD Config Management Plugins](https://argo-cd.readthedocs.io/en/stable/operator-manual/config-management-plugins/)
+- [Argo CD secret management](https://argo-cd.readthedocs.io/en/stable/operator-manual/secret-management/)
+- [Argo CD private repositories](https://argo-cd.readthedocs.io/en/stable/user-guide/private-repositories/)

--- a/notes/ideas/local-dev.md
+++ b/notes/ideas/local-dev.md
@@ -1,0 +1,327 @@
+# Local Development with Tilt
+
+## Purpose
+
+Describe how the desktop should remain a fast, isolated development environment after the permanent Talos-based homelab cluster exists.
+
+The permanent cluster should run the stable version of the homelab. The desktop should provide a disposable local Kubernetes environment where application changes can be developed and tested before they are committed, reviewed, and deployed to the permanent cluster.
+
+## Recommended Split
+
+Use different tools and clusters for different jobs:
+
+```text
+Desktop development:
+  K3s + Helmfile + Tilt + local registry
+
+Permanent homelab:
+  Talos + Kubernetes + Helmfile initially
+  Argo CD optionally later
+```
+
+Tilt is a development loop, not the production deployment controller. It watches source files, rebuilds or live-updates application containers, applies local Kubernetes resources, and provides fast feedback while code is changing.
+
+The permanent cluster should use the normal deployment workflow. That can initially be helmfile sync and could later become Argo CD reconciliation if the operational benefits justify the additional system.
+
+## What the Current Tiltfile Already Does
+
+The current Tiltfile targets app-owned workloads rather than the entire infrastructure stack.
+
+It currently:
+
+- Restricts Tilt to an allowed Kubernetes context.
+- Renders app releases with helmfile -e dev -l bootstrap=app template.
+- Watches Helmfile, the reusable workload chart, application values, and encrypted secret files.
+- Builds application images for the local registry.home:5000 registry.
+- Live-syncs Python, Node, and other source files into running pods.
+- Uses development process commands such as Uvicorn reload and Next.js development mode.
+- Rebuilds images when Dockerfiles, dependency lockfiles, or other image inputs change.
+- Compiles the Go example locally and syncs the resulting binary into the pod.
+- Applies the runner RBAC manifest directly because Helmfile presync hooks do not execute during helmfile template.
+- Exposes useful application and health links in the Tilt UI.
+
+The existing values-dev.yaml.gotmpl files also provide a useful environment boundary. They enable development-only commands and single-replica behavior while rendering to empty values outside the dev environment.
+
+## What Tilt Is Good At
+
+### Fast source feedback
+
+Editing application source should usually update the running pod without rebuilding the entire image. The current Python applications sync source into /app, Uvicorn or Django reloads the process, and the Node application runs its development server.
+
+### Application-focused iteration
+
+Tilt can manage the application layer while shared infrastructure such as Postgres, Prometheus, Traefik, and the local registry remains installed in the desktop K3s cluster.
+
+### Local Kubernetes fidelity
+
+Running the applications in Kubernetes catches issues that a host-only development server would miss, including service discovery, environment injection, probes, ingress behavior, mounted secrets, resource settings, and inter-service communication.
+
+### Development visibility
+
+The Tilt UI provides resource logs, build status, live-update status, deployment failures, and links to the running services.
+
+## What Tilt Should Not Do
+
+Tilt should not be pointed at the permanent cluster. It should not:
+
+- Live-sync source into production pods.
+- Rebuild or overwrite production image tags.
+- Apply development values to production workloads.
+- Use production database credentials.
+- Push development images to the production registry.
+- Manage production infrastructure or persistent data.
+- Become the production source of truth.
+
+The production cluster should receive reviewed configuration through the production deployment workflow, not through an active developer process on the desktop.
+
+## Desktop Development Cluster
+
+The desktop should run its own local K3s cluster. It can be created using the existing make up workflow or a future development-specific wrapper around that workflow.
+
+The local cluster should have enough shared infrastructure for the applications to behave realistically:
+
+- Traefik or another ingress controller.
+- A local Postgres instance.
+- A local container registry.
+- Longhorn or another local storage option if the applications require persistent volumes.
+- Any infrastructure service required by the application being developed.
+
+The local cluster does not necessarily need every production service. A smaller development profile could omit monitoring, logging, Home Assistant, Pi-hole, Authentik, or other services unless the change under test depends on them.
+
+The current Tiltfile expects infrastructure to already exist because it renders only app releases. A fresh desktop development cluster therefore needs an infrastructure bootstrap before make dev can work.
+
+The intended layering is:
+
+```text
+Local K3s bootstrap
+  └── shared development infrastructure
+        └── Tilt-managed application workloads
+```
+
+## Suggested Daily Workflow
+
+The eventual workflow should look like this:
+
+```text
+1. Start or select the isolated desktop K3s context.
+2. Ensure the local development infrastructure is running.
+3. Start Tilt.
+4. Edit application source and use live updates.
+5. Run tests, migrations, and application checks locally.
+6. Commit the change on a feature branch.
+7. Open a pull request and let CI validate it.
+8. Merge the change.
+9. Deploy the reviewed change to the permanent cluster through Helmfile or Argo CD.
+```
+
+With the current commands, the rough flow is:
+
+```bash
+# One-time or after rebuilding the local cluster
+make up
+
+# Start the local application development loop
+make dev
+
+# Apply new Django migrations manually when needed
+make migrate
+
+# Stop Tilt-managed application resources
+make dev-down
+
+# Remove the disposable local cluster when desired
+make down
+```
+
+These commands are intentionally different from the future production workflow. make dev should remain a local-development command, while production deployment should be a separate explicit action.
+
+## Cluster Context Safety
+
+The most important safety property is making it difficult for Tilt to target the permanent cluster accidentally.
+
+The current Tiltfile uses an allowed context named default. That is useful today, but the context name should become an explicit development-only name before the permanent cluster is introduced. For example:
+
+```text
+homelab-dev
+homelab-prod
+```
+
+The Tiltfile should allow only homelab-dev. Production should use a different context and should be rejected by Tilt before any resources are applied.
+
+The Makefile and helper scripts should eventually make the distinction equally obvious. A future make dev wrapper could verify the active context, while production deployment could require an explicit production context or a separate command.
+
+The goal is defense in depth:
+
+```text
+Tilt allowlist
+  + explicit kubeconfig context names
+  + separate registry and image names
+  + separate DNS/ingress names
+  + separate secrets
+  = low chance of accidental production changes
+```
+
+## Registry and Image Isolation
+
+The current development workflow targets:
+
+```text
+registry.home:5000/homelab/<app>:dev
+```
+
+That is appropriate for a local development registry, but it becomes dangerous if the desktop and permanent cluster use the same registry and mutable dev tags at the same time. A local Tilt build could overwrite an image that production is using.
+
+The safer future design is:
+
+```text
+Development:
+  registry.dev.home:5000/homelab/<app>:dev
+
+Production:
+  production registry or registry.home:5000/homelab/<app>:release-<version>
+```
+
+At minimum, development and production should have separate registries or separate image namespaces. Immutable production tags or image digests should be used for the permanent cluster.
+
+The desktop build process should remain fast and disposable. The production build process should produce a traceable image from a reviewed commit and publish a version that the production deployment explicitly references.
+
+## DNS and Ingress Isolation
+
+The current applications use .home hostnames such as api.home, agenda.home, and grafana.home. That works when the desktop is the only cluster using the local DNS configuration, but it becomes ambiguous if the desktop development cluster and permanent cluster run at the same time.
+
+Before both clusters are used concurrently, introduce a clear naming scheme, for example:
+
+```text
+Development:
+  api.dev.home
+  agenda.dev.home
+  registry.dev.home
+
+Permanent cluster:
+  api.home
+  agenda.home
+  registry.home
+```
+
+The exact suffix is less important than ensuring that a browser request or Docker push cannot silently resolve to the wrong cluster.
+
+The development DNS layer could use a local resolver, /etc/hosts, a dedicated Pi-hole configuration, or another split-DNS arrangement. The permanent cluster should not depend on the desktop's Pi-hole being active.
+
+This likely requires values changes because the current development overlays mainly change process arguments and replica behavior; they do not yet provide a separate ingress-host convention.
+
+## Secrets and Development Data
+
+The local cluster should never use production credentials or production data unless there is a deliberate, documented reason.
+
+The current Tiltfile watches application secrets.sops.yaml files, and Helmfile decrypts them during development rendering. Once a permanent cluster exists, this should be reviewed carefully because the same encrypted files may currently be used for both local and future production environments.
+
+Prefer separate encrypted development secrets where necessary:
+
+```text
+services/postgres/secrets-dev.sops.yaml
+services/postgres/secrets.sops.yaml
+apps/api/secrets-dev.sops.yaml
+apps/api/secrets.sops.yaml
+```
+
+Development secrets should use disposable credentials, local OAuth redirect URLs, local API keys, and non-production tokens. Development databases should be initialized with safe test data or empty schemas rather than copies of private production data.
+
+If the same secret file is intentionally shared, that should be an explicit decision rather than an accidental consequence of Helmfile values merging.
+
+## Shared Configuration Versus Environment Differences
+
+The local and permanent clusters should share as much application behavior as possible:
+
+- Application source code.
+- Dockerfiles.
+- The reusable workload chart.
+- Base Helm values.
+- Service names and internal API contracts.
+- Health checks and metrics configuration.
+- SOPS file structure and secret key names.
+- CI validation and test commands.
+
+They should differ where the environment genuinely differs:
+
+- Kubernetes context.
+- Image registry and image tag policy.
+- Ingress hostnames.
+- Replica counts and autoscaling.
+- Development reload commands.
+- Resource requests and limits.
+- Persistent storage settings.
+- External OAuth redirect URLs.
+- Development versus production credentials.
+- Monitoring and logging scope.
+
+The existing values-dev.yaml.gotmpl pattern is a reasonable starting point for process and replica differences. It should not become a place to hide broad infrastructure divergence indefinitely; larger differences should eventually be represented as clearly named environment values or separate profiles.
+
+## Database Migrations
+
+Database migrations should remain an explicit development action. The current entrypoint only migrates an uninitialized database, and the repository already provides make migrate.
+
+The local workflow should therefore be:
+
+```text
+Edit model/schema
+  -> generate migration
+  -> review migration
+  -> run make migrate against local Postgres
+  -> test application behavior
+```
+
+The production migration path should remain separate and deliberate. A local Tilt reload should not automatically run migrations against any database other than the isolated local development database.
+
+## Relationship to Production Helmfile or Argo CD
+
+Tilt should not need to know whether production eventually uses Helmfile or Argo CD. Its job is to render and apply the local development application layer.
+
+The desired repository flow is:
+
+```text
+Feature branch
+  └── local K3s + Tilt
+        └── fast source feedback and integration testing
+              └── pull request and CI validation
+                    └── merge to main
+                          └── production Helmfile sync or Argo CD reconciliation
+```
+
+The same Helm chart and application values can support both environments, while Tilt selects the local development values and image workflow.
+
+If Argo CD is adopted later, it should manage only the permanent cluster. The desktop should continue using Tilt because continuous Git reconciliation is not a substitute for live source syncing and reload-based development.
+
+## Possible Future Commands
+
+The current commands are sufficient for now, but the long-term operator experience could become more explicit:
+
+```bash
+make dev-up       # start or bootstrap the isolated desktop K3s cluster
+make dev          # start Tilt against the development context
+make dev-migrate  # apply local database migrations
+make dev-down     # stop Tilt-managed resources
+make dev-reset    # intentionally destroy and recreate local state
+make sync         # manually deploy the permanent cluster if Helmfile remains
+```
+
+These are proposed commands rather than current Makefile targets. The important design decision is the separation between local development lifecycle commands and permanent-cluster deployment commands.
+
+## Recommendation
+
+Keep using the current K3s plus Tilt workflow on the desktop. It is already aligned with the desired local development experience and is appropriate for an ephemeral environment.
+
+When the mini-PCs arrive, set up Talos and the permanent Kubernetes cluster independently. Initially continue using Helmfile for production deployment so the operating-system migration and deployment-controller migration do not happen at the same time.
+
+Keep the desktop development cluster separate and disposable. Start it with the shared infrastructure required by the applications, then run Tilt only against the development context and development registry.
+
+Before the two environments run concurrently, add explicit isolation for Kubernetes contexts, registry endpoints, image tags, DNS names, ingress hosts, and secrets. This is more important than whether the permanent cluster eventually uses Helmfile or Argo CD.
+
+Explore Argo CD later if the permanent cluster would benefit from continuous reconciliation, drift correction, deployment history, or eliminating manual production sync commands. Argo CD should manage the permanent cluster; Tilt should remain the fast local development loop.
+
+## References
+
+- [Tiltfile](../../Tiltfile)
+- [Makefile](../../Makefile)
+- [helmfile.yaml](../../helmfile.yaml)
+- [Tilt documentation](https://docs.tilt.dev/)
+- [Tilt live update](https://docs.tilt.dev/live_update_reference.html)


### PR DESCRIPTION
## Description

Document the planned separation between local K3s/Tilt development and the future Talos homelab deployment workflow, including the possible later adoption of Argo CD.

## Added

- Argo CD, Helmfile, Talos, and SOPS design notes.
- Tilt-based local development workflow with cluster, registry, DNS, image, and secret isolation guidance.