### PR TITLE
chore: improve postgres chart and ci quality checks

### DIFF
--- a/.github/workflows/dagster.yaml
+++ b/.github/workflows/dagster.yaml
@@ -5,11 +5,13 @@ on:
     branches: [main]
     paths:
       - "apps/dagster/**"
+      - "apps/django/schema/**"
       - ".github/workflows/dagster.yaml"
   pull_request:
     branches: [main]
     paths:
       - "apps/dagster/**"
+      - "apps/django/schema/**"
       - ".github/workflows/dagster.yaml"
 
 concurrency:

--- a/.github/workflows/python-quality.yaml
+++ b/.github/workflows/python-quality.yaml
@@ -3,10 +3,18 @@ name: Python Quality
 on:
   push:
     branches: [main]
+    paths:
+      - "apps/**/*.py"
+      - "apps/**/*.pyi"
+      - "apps/**/pyproject.toml"
+      - "apps/**/uv.lock"
+      - "ruff.toml"
+      - ".github/workflows/python-quality.yaml"
   pull_request:
     branches: [main]
     paths:
       - "apps/**/*.py"
+      - "apps/**/*.pyi"
       - "apps/**/pyproject.toml"
       - "apps/**/uv.lock"
       - "ruff.toml"
@@ -26,7 +34,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          sparse-checkout: apps
+          sparse-checkout: |
+            apps
+            ruff.toml
+          sparse-checkout-cone-mode: false
 
       - name: Setup Ruff
         uses: astral-sh/ruff-action@v3
@@ -43,9 +54,7 @@ jobs:
     name: Detect Python App Changes
     runs-on: ubuntu-latest
     outputs:
-      services:
-        ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' &&
-        '["api", "dagster", "django","runner"]' || steps.filter.outputs.changes }}
+      services: ${{ steps.filter.outputs.changes }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -7,6 +7,7 @@ on:
       - "apps/tools/**"
       - ".github/workflows/tools.yaml"
   pull_request:
+    branches: [main]
     paths:
       - "apps/tools/**"
       - ".github/workflows/tools.yaml"

--- a/services/postgres/chart/templates/postgres.yaml
+++ b/services/postgres/chart/templates/postgres.yaml
@@ -98,7 +98,7 @@ spec:
     spec:
       containers:
         - name: postgres
-          image: postgres:17
+          image: {{ printf "%s:%s" (required "postgres.image.repository is required" .Values.postgres.image.repository) (required "postgres.image.tag is required" .Values.postgres.image.tag) | quote }}
           env:
             - name: POSTGRES_USER
               valueFrom:

--- a/services/postgres/chart/tests/postgres_test.yaml
+++ b/services/postgres/chart/tests/postgres_test.yaml
@@ -74,7 +74,7 @@ tests:
           path: spec.clusterIP
           value: None
 
-  - it: should create a statefulset with postgres 17 image
+  - it: should create a statefulset with the configured postgres image
     documentIndex: 5
     asserts:
       - isKind:
@@ -91,6 +91,16 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 5432
+
+  - it: should allow overriding the postgres image and tag
+    set:
+      postgres.image.repository: postgres
+      postgres.image.tag: "18"
+    documentIndex: 5
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "postgres:18"
 
   - it: should create a 4Gi PVC with longhorn storage class
     documentIndex: 5

--- a/services/postgres/chart/values.yaml
+++ b/services/postgres/chart/values.yaml
@@ -1,4 +1,7 @@
 postgres:
+  image:
+    repository: postgres
+    tag: "17"
   username: postgres
   password: replace-me
 


### PR DESCRIPTION
## Description

Improve Postgres image configurability and prevent irrelevant Python type-check jobs from running after merges.

### Updated

- Template the Postgres image repository and tag, with Helm unit-test coverage for overrides.
- Scope Python quality pushes and `ty` matrices to changed Python apps, and include Ruff configuration in checkout.
- Align Dagster and Tools workflow path triggers with their actual inputs and target branch.